### PR TITLE
MAKE-820: request and sign certificates in memory

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -59,6 +59,10 @@ type CertificateOptions struct {
 	CAPassphrase string `bson:"ca_passphrase,omitempty" json:"ca_passphrase,omitempty" yaml:"ca_passphrase,omitempty"`
 	// Whether generated certificate should be an intermediate.
 	Intermediate bool `bson:"intermediate,omitempty" json:"intermediate,omitempty" yaml:"intermediate,omitempty"`
+
+	csr  *pkix.CertificateSigningRequest
+	key  *pkix.Key
+	cert *pkix.Certificate
 }
 
 // Init initializes a new CA.
@@ -72,7 +76,7 @@ func (opts *CertificateOptions) Init(d depot.Depot) error {
 		return errors.New("CA with specified name already exists")
 	}
 
-	key, err := opts.getOrCreatePrivateKey(formattedName)
+	key, err := opts.getOrCreatePrivateKey()
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -118,34 +122,38 @@ func (opts *CertificateOptions) Init(d depot.Depot) error {
 	return nil
 }
 
-// CertRequest creates a new certificate (CSR).
+// CertRequest creates a new certificate signing request (CSR) and key and puts
+// them in the depot.
 func (opts *CertificateOptions) CertRequest(d depot.Depot) error {
+	if _, _, err := opts.CertRequestInMemory(d); err != nil {
+		return errors.Wrap(err, "problem creating cert request and key")
+	}
+
+	return opts.PutCertRequestFromMemory(d)
+}
+
+// CertRequestInMemory is the same as CertRequest but returns the resulting
+// certificate signing request and private key without putting them in the
+// depot. Use PutCertRequestFromMemory to put the certificate in the depot.
+func (opts *CertificateOptions) CertRequestInMemory(d depot.Depot) (*pkix.CertificateSigningRequest, *pkix.Key, error) {
 	ips, err := pkix.ParseAndValidateIPs(strings.Join(opts.IP, ","))
 	if err != nil {
-		return errors.Wrapf(err, "problem parsing and validating IPs: %s", opts.IP)
+		return nil, nil, errors.Wrapf(err, "problem parsing and validating IPs: %s", opts.IP)
 	}
 
 	uris, err := pkix.ParseAndValidateURIs(strings.Join(opts.URI, ","))
 	if err != nil {
-		return errors.Wrapf(err, "problem parsing and validating URIs: %s", opts.URI)
+		return nil, nil, errors.Wrapf(err, "problem parsing and validating URIs: %s", opts.URI)
 	}
 
 	name, err := opts.getCertificateRequestName()
 	if err != nil {
-		return errors.WithStack(err)
-	}
-	formattedName, err := formatName(name)
-	if err != nil {
-		return errors.Wrap(err, "problem getting formatted name")
+		return nil, nil, errors.WithStack(err)
 	}
 
-	if depot.CheckCertificateSigningRequest(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
-		return errors.New("certificate request has existed")
-	}
-
-	key, err := opts.getOrCreatePrivateKey(formattedName)
+	key, err := opts.getOrCreatePrivateKey()
 	if err != nil {
-		return errors.WithStack(err)
+		return nil, nil, errors.WithStack(err)
 	}
 
 	csr, err := pkix.CreateCertificateSigningRequest(
@@ -161,18 +169,41 @@ func (opts *CertificateOptions) CertRequest(d depot.Depot) error {
 		name,
 	)
 	if err != nil {
-		return errors.Wrap(err, "problem creating certificate request")
+		return nil, nil, errors.Wrap(err, "problem creating certificate request")
 	}
 
-	if err = depot.PutCertificateSigningRequest(d, formattedName, csr); err != nil {
+	opts.csr = csr
+	opts.key = key
+
+	return csr, key, nil
+}
+
+// PutCertRequestFromMemory stores the certificate request and key generated
+// from the options in the depot.
+func (opts *CertificateOptions) PutCertRequestFromMemory(d depot.Depot) error {
+	if opts.csr == nil || opts.key == nil {
+		return errors.New("must make cert request and key first before putting into depot")
+	}
+
+	formattedName, err := opts.getFormattedCertificateRequestName()
+	if err != nil {
+		return errors.Wrap(err, "problem getting formatted name")
+	}
+
+	if depot.CheckCertificateSigningRequest(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
+		return errors.New("certificate request has existed")
+	}
+
+	if err = depot.PutCertificateSigningRequest(d, formattedName, opts.csr); err != nil {
 		return errors.Wrap(err, "problem saving certificate request")
 	}
+
 	if opts.Passphrase != "" {
-		if err = depot.PutEncryptedPrivateKey(d, formattedName, key, []byte(opts.Passphrase)); err != nil {
+		if err = depot.PutEncryptedPrivateKey(d, formattedName, opts.key, []byte(opts.Passphrase)); err != nil {
 			return errors.Wrap(err, "problem saving encrypted private key")
 		}
 	} else {
-		if err = depot.PutPrivateKey(d, formattedName, key); err != nil {
+		if err = depot.PutPrivateKey(d, formattedName, opts.key); err != nil {
 			return errors.Wrap(err, "problem saving private key error")
 		}
 	}
@@ -182,50 +213,62 @@ func (opts *CertificateOptions) CertRequest(d depot.Depot) error {
 
 // Sign signs a CSR with a given CA for a new certificate.
 func (opts *CertificateOptions) Sign(d depot.Depot) error {
+	_, err := opts.SignInMemory(d)
+	if err != nil {
+		return errors.Wrap(err, "problem signing certificate request")
+	}
+
+	return opts.PutCertFromMemory(d)
+}
+
+// SignInMemory is the same as Sign but returns the resulting certificate
+// without putting it in the depot. Use PutCertFromMemory to put the certificate
+// in the depot.
+func (opts *CertificateOptions) SignInMemory(d depot.Depot) (*pkix.Certificate, error) {
 	if opts.Host == "" {
-		return errors.New("must provide name of host")
+		return nil, errors.New("must provide name of host")
 	}
 	if opts.CA == "" {
-		return errors.New("must provide name of CA")
+		return nil, errors.New("must provide name of CA")
 	}
 	formattedReqName := strings.Replace(opts.Host, " ", "_", -1)
 	formattedCAName := strings.Replace(opts.CA, " ", "_", -1)
 
-	if depot.CheckCertificate(d, formattedReqName) {
-		return errors.New("certificate has existed")
-	}
-
-	csr, err := depot.GetCertificateSigningRequest(d, formattedReqName)
-	if err != nil {
-		return errors.Wrap(err, "problem getting host's certificate signing request")
+	csr := opts.csr
+	if csr == nil {
+		var err error
+		csr, err = depot.GetCertificateSigningRequest(d, formattedReqName)
+		if err != nil {
+			return nil, errors.Wrap(err, "problem getting host's certificate signing request")
+		}
 	}
 	crt, err := depot.GetCertificate(d, formattedCAName)
 	if err != nil {
-		return errors.Wrap(err, "problem getting CA certificate")
+		return nil, errors.Wrap(err, "problem getting CA certificate")
 	}
 
 	// validate that crt is allowed to sign certificates
 	rawCrt, err := crt.GetRawCertificate()
 	if err != nil {
-		return errors.Wrap(err, "problem getting raw CA certificate")
+		return nil, errors.Wrap(err, "problem getting raw CA certificate")
 	}
 	// we punt on checking BasicConstraintsValid and checking MaxPathLen. The goal
 	// is to prevent accidentally creating invalid certificates, not protecting
 	// against malicious input.
 	if !rawCrt.IsCA {
-		return errors.Errorf("%s is not allowed to sign certificates", opts.CA)
+		return nil, errors.Errorf("%s is not allowed to sign certificates", opts.CA)
 	}
 
 	var key *pkix.Key
 	if opts.CAPassphrase == "" {
 		key, err = depot.GetPrivateKey(d, formattedCAName)
 		if err != nil {
-			return errors.Wrap(err, "problem getting unencrypted (assumed) CA key")
+			return nil, errors.Wrap(err, "problem getting unencrypted (assumed) CA key")
 		}
 	} else {
 		key, err = depot.GetEncryptedPrivateKey(d, formattedCAName, []byte(opts.CAPassphrase))
 		if err != nil {
-			return errors.Wrap(err, "problem getting encrypted CA key")
+			return nil, errors.Wrap(err, "problem getting encrypted CA key")
 		}
 	}
 
@@ -237,14 +280,39 @@ func (opts *CertificateOptions) Sign(d depot.Depot) error {
 		crtOut, err = pkix.CreateCertificateHost(crt, key, csr, expiresTime)
 	}
 	if err != nil {
-		return errors.Wrap(err, "problem creating certificate")
+		return nil, errors.Wrap(err, "problem creating certificate")
 	}
 
-	if err = depot.PutCertificate(d, formattedReqName, crtOut); err != nil {
-		return errors.Wrap(err, "problem saving certificate")
+	opts.cert = crtOut
+
+	return crtOut, nil
+}
+
+// PutCertFromMemory stores the certificate generated from the options in the
+// depot.
+func (opts *CertificateOptions) PutCertFromMemory(d depot.Depot) error {
+	if opts.cert == nil {
+		return errors.New("must sign cert first before putting into depot")
+	}
+	formattedReqName := strings.Replace(opts.Host, " ", "_", -1)
+
+	if depot.CheckCertificate(d, formattedReqName) {
+		return errors.New("certificate has existed")
 	}
 
-	return nil
+	return errors.Wrap(depot.PutCertificate(d, formattedReqName, opts.cert), "problem saving certificate")
+}
+
+func (opts CertificateOptions) getFormattedCertificateRequestName() (string, error) {
+	name, err := opts.getCertificateRequestName()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get name for certificate request")
+	}
+	filenameAcceptable, err := regexp.Compile("[^a-zA-Z0-9._-]")
+	if err != nil {
+		return "", errors.Wrap(err, "error compiling regex")
+	}
+	return string(filenameAcceptable.ReplaceAll([]byte(name), []byte("_"))), nil
 }
 
 func (opts CertificateOptions) getCertificateRequestName() (string, error) {
@@ -258,7 +326,7 @@ func (opts CertificateOptions) getCertificateRequestName() (string, error) {
 	}
 }
 
-func (opts CertificateOptions) getOrCreatePrivateKey(name string) (*pkix.Key, error) {
+func (opts CertificateOptions) getOrCreatePrivateKey() (*pkix.Key, error) {
 	var key *pkix.Key
 	if opts.Key != "" {
 		keyBytes, err := ioutil.ReadFile(opts.Key)
@@ -280,14 +348,6 @@ func (opts CertificateOptions) getOrCreatePrivateKey(name string) (*pkix.Key, er
 		}
 	}
 	return key, nil
-}
-
-func formatName(name string) (string, error) {
-	var filenameAcceptable, err = regexp.Compile("[^a-zA-Z0-9._-]")
-	if err != nil {
-		return "", errors.Wrap(err, "problem compiling regex")
-	}
-	return string(filenameAcceptable.ReplaceAll([]byte(name), []byte("_"))), nil
 }
 
 func getNameAndKey(tag *depot.Tag) (string, string) {

--- a/cert.go
+++ b/cert.go
@@ -122,6 +122,16 @@ func (opts *CertificateOptions) Init(d depot.Depot) error {
 	return nil
 }
 
+// Reset clears the cached results of CertificateOptions so that the options can
+// be changed after a certificate has already been requested or signed. For
+// example, if the options have been modified, a new certificate request can be
+// made with the new options by using Reset.
+func (opts *CertificateOptions) Reset() {
+	opts.csr = nil
+	opts.key = nil
+	opts.crt = nil
+}
+
 // CertRequest creates a new certificate signing request (CSR) and key and puts
 // them in the depot.
 func (opts *CertificateOptions) CertRequest(d depot.Depot) error {

--- a/cert_test.go
+++ b/cert_test.go
@@ -329,6 +329,8 @@ func TestCertRequest(t *testing.T) {
 		*/
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			opts.Reset()
+			defer opts.Reset()
 			test.changeOpts()
 			err = opts.CertRequest(d)
 
@@ -371,13 +373,6 @@ func TestInMemory(t *testing.T) {
 			catcher.Add(d.Delete(crtTag))
 		}
 		return catcher.Resolve()
-	}
-
-	// Resets in-memory state
-	resetOpts := func(opts *CertificateOptions) {
-		opts.csr = nil
-		opts.key = nil
-		opts.crt = nil
 	}
 
 	for testName, testCase := range map[string]func(t *testing.T, d depot.Depot, opts *CertificateOptions){
@@ -460,11 +455,11 @@ func TestInMemory(t *testing.T) {
 				t.Run(subTestName, func(t *testing.T) {
 					name, err := opts.getFormattedCertificateRequestName()
 					require.NoError(t, err)
+					opts.Reset()
 					require.NoError(t, clearByName(d, name))
-					resetOpts(opts)
 					defer func() {
+						opts.Reset()
 						assert.NoError(t, clearByName(d, name))
-						resetOpts(opts)
 					}()
 
 					subTestCase(t, name)
@@ -501,11 +496,11 @@ func TestInMemory(t *testing.T) {
 				t.Run(subTestName, func(t *testing.T) {
 					name, err := opts.getFormattedCertificateRequestName()
 					require.NoError(t, err)
+					opts.Reset()
 					require.NoError(t, clearByName(d, name))
-					resetOpts(opts)
 					defer func() {
+						opts.Reset()
 						assert.NoError(t, clearByName(d, name))
-						resetOpts(opts)
 					}()
 
 					subTestCase(t, name)
@@ -587,11 +582,11 @@ func TestInMemory(t *testing.T) {
 				t.Run(subTestName, func(t *testing.T) {
 					name, err := opts.getFormattedCertificateRequestName()
 					require.NoError(t, err)
+					opts.Reset()
 					require.NoError(t, clearByName(d, name))
-					resetOpts(opts)
 					defer func() {
+						opts.Reset()
 						assert.NoError(t, clearByName(d, name))
-						resetOpts(opts)
 					}()
 
 					subTestCase(t, name)
@@ -620,12 +615,12 @@ func TestInMemory(t *testing.T) {
 				t.Run(subTestName, func(t *testing.T) {
 					name, err := opts.getFormattedCertificateRequestName()
 					require.NoError(t, err)
+					opts.Reset()
 					require.NoError(t, clearByName(d, name))
-					resetOpts(opts)
 
 					defer func() {
+						opts.Reset()
 						assert.NoError(t, clearByName(d, name))
-						resetOpts(opts)
 					}()
 
 					subTestCase(t, name)
@@ -821,6 +816,12 @@ func TestSign(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			crtOpts.Reset()
+			csrOpts.Reset()
+			defer func() {
+				csrOpts.Reset()
+				crtOpts.Reset()
+			}()
 			test.changeOpts()
 			err = crtOpts.Sign(d)
 
@@ -910,6 +911,7 @@ func TestCreateCertificateOnExpiration(t *testing.T) {
 	assert.True(t, rawUserCrt.NotAfter.After(time.Now().Add(23*time.Hour)))
 
 	// user cert exists and expiring
+	opts.Reset()
 	opts.Expires = time.Hour
 	created, err = opts.CreateCertificateOnExpiration(d, 25*time.Hour)
 	assert.NoError(t, err)

--- a/cert_test.go
+++ b/cert_test.go
@@ -3,6 +3,7 @@ package certdepot
 import (
 	"context"
 	"crypto/rsa"
+	"crypto/x509"
 	"io/ioutil"
 	"net"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mongodb/grip"
 	"github.com/square/certstrap/depot"
 	"github.com/square/certstrap/pkix"
 	"github.com/stretchr/testify/assert"
@@ -352,6 +354,327 @@ func TestCertRequest(t *testing.T) {
 				test.keyTest()
 			}
 		})
+	}
+}
+
+func TestInMemory(t *testing.T) {
+	// Resets depot state
+	clearByName := func(d depot.Depot, name string) error {
+		catcher := grip.NewBasicCatcher()
+		if csrTag := depot.CsrTag(name); d.Check(csrTag) {
+			catcher.Add(d.Delete(csrTag))
+		}
+		if keyTag := depot.PrivKeyTag(name); d.Check(keyTag) {
+			catcher.Add(d.Delete(keyTag))
+		}
+		if crtTag := depot.CrtTag(name); d.Check(crtTag) {
+			catcher.Add(d.Delete(crtTag))
+		}
+		return catcher.Resolve()
+	}
+
+	// Resets in-memory state
+	resetOpts := func(opts *CertificateOptions) {
+		opts.csr = nil
+		opts.key = nil
+		opts.crt = nil
+	}
+
+	for testName, testCase := range map[string]func(t *testing.T, d depot.Depot, opts *CertificateOptions){
+		"CertRequestInMemory": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+			checkMatchingCSR := func(t *testing.T, opts *CertificateOptions, rawCSR *x509.CertificateRequest) {
+				assert.Equal(t, opts.CommonName, rawCSR.Subject.CommonName)
+				assert.Equal(t, []string{opts.Organization}, rawCSR.Subject.Organization)
+				assert.Equal(t, []string{opts.Country}, rawCSR.Subject.Country)
+				assert.Equal(t, []string{opts.Locality}, rawCSR.Subject.Locality)
+				assert.Equal(t, []string{opts.OrganizationalUnit}, rawCSR.Subject.OrganizationalUnit)
+				assert.Equal(t, []string{opts.Province}, rawCSR.Subject.Province)
+				assert.Equal(t, convertIPs(opts.IP), rawCSR.IPAddresses)
+				assert.Equal(t, opts.Domain, rawCSR.DNSNames)
+			}
+
+			exportCSRAndKey := func(t *testing.T, csr *pkix.CertificateSigningRequest, key *pkix.Key) ([]byte, []byte) {
+				pemCSR, err := csr.Export()
+				require.NoError(t, err)
+				pemKey, err := key.ExportPrivate()
+				require.NoError(t, err)
+				return pemCSR, pemKey
+			}
+
+			for subTestName, subTestCase := range map[string]func(t *testing.T, name string){
+				"Succeeds": func(t *testing.T, name string) {
+					csr, _, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+
+					rawCSR, err := csr.GetRawCertificateSigningRequest()
+					require.NoError(t, err)
+
+					checkMatchingCSR(t, opts, rawCSR)
+
+					assert.False(t, depot.CheckCertificateSigningRequest(d, name))
+					assert.False(t, depot.CheckPrivateKey(d, name))
+				},
+				"SucceedsAfterCertRequestInDepot": func(t *testing.T, name string) {
+					require.NoError(t, opts.CertRequest(d))
+					csr, key, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+
+					pemCSR, pemKey := exportCSRAndKey(t, csr, key)
+
+					dbCSR, err := d.Get(depot.CsrTag(name))
+					require.NoError(t, err)
+
+					dbKey, err := d.Get(depot.PrivKeyTag(name))
+					require.NoError(t, err)
+
+					assert.Equal(t, dbCSR, pemCSR)
+					assert.Equal(t, dbKey, pemKey)
+				},
+				"ReturnsIdenticalAsSubsequentCertRequest": func(t *testing.T, name string) {
+					csr, key, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+					pemCSR, pemKey := exportCSRAndKey(t, csr, key)
+
+					require.NoError(t, opts.CertRequest(d))
+					dbCSR, err := d.Get(depot.CsrTag(name))
+					require.NoError(t, err)
+					dbKey, err := d.Get(depot.PrivKeyTag(name))
+					require.NoError(t, err)
+
+					assert.Equal(t, dbCSR, pemCSR)
+					assert.Equal(t, dbKey, pemKey)
+				},
+				"ReturnsIdenticalOnSubsequentCalls": func(t *testing.T, name string) {
+					csr, key, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+					pemCSR, pemKey := exportCSRAndKey(t, csr, key)
+
+					sameCSR, sameKey, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+					pemSameCSR, pemSameKey := exportCSRAndKey(t, sameCSR, sameKey)
+
+					assert.Equal(t, pemCSR, pemSameCSR)
+					assert.Equal(t, pemKey, pemSameKey)
+				},
+			} {
+				t.Run(subTestName, func(t *testing.T) {
+					name, err := opts.getFormattedCertificateRequestName()
+					require.NoError(t, err)
+					require.NoError(t, clearByName(d, name))
+					resetOpts(opts)
+					defer func() {
+						assert.NoError(t, clearByName(d, name))
+						resetOpts(opts)
+					}()
+
+					subTestCase(t, name)
+				})
+			}
+		},
+		"PutCertRequest": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+			for subTestName, subTestCase := range map[string]func(t *testing.T, name string){
+				"FailsWithoutCertRequestInMemory": func(t *testing.T, name string) {
+					assert.Error(t, opts.PutCertRequestFromMemory(d))
+				},
+				"FailsAfterCertRequest": func(t *testing.T, name string) {
+					require.NoError(t, opts.CertRequest(d))
+					assert.Error(t, opts.PutCertRequestFromMemory(d))
+				},
+				"SucceedsAfterCertRequestInMemory": func(t *testing.T, name string) {
+					csr, key, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+					require.NoError(t, opts.PutCertRequestFromMemory(d))
+
+					pemCSR, err := csr.Export()
+					require.NoError(t, err)
+					depotCSR, err := d.Get(depot.CsrTag(name))
+					require.NoError(t, err)
+					assert.Equal(t, pemCSR, depotCSR)
+
+					pemKey, err := key.ExportPrivate()
+					require.NoError(t, err)
+					depotKey, err := d.Get(depot.PrivKeyTag(name))
+					require.NoError(t, err)
+					assert.Equal(t, pemKey, depotKey)
+				},
+			} {
+				t.Run(subTestName, func(t *testing.T) {
+					name, err := opts.getFormattedCertificateRequestName()
+					require.NoError(t, err)
+					require.NoError(t, clearByName(d, name))
+					resetOpts(opts)
+					defer func() {
+						assert.NoError(t, clearByName(d, name))
+						resetOpts(opts)
+					}()
+
+					subTestCase(t, name)
+				})
+			}
+		},
+		"SignInMemory": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+			checkMatchingCert := func(t *testing.T, opts *CertificateOptions, rawCrt *x509.Certificate) {
+				assert.Equal(t, opts.CommonName, rawCrt.Subject.CommonName)
+				assert.Equal(t, []string{opts.Organization}, rawCrt.Subject.Organization)
+				assert.Equal(t, []string{opts.Country}, rawCrt.Subject.Country)
+				assert.Equal(t, []string{opts.Locality}, rawCrt.Subject.Locality)
+				assert.Equal(t, []string{opts.OrganizationalUnit}, rawCrt.Subject.OrganizationalUnit)
+				assert.Equal(t, []string{opts.Province}, rawCrt.Subject.Province)
+				assert.Equal(t, convertIPs(opts.IP), rawCrt.IPAddresses)
+				assert.Equal(t, opts.Domain, rawCrt.DNSNames)
+			}
+
+			for subTestName, subTestCase := range map[string]func(t *testing.T, name string){
+				"FailsWithoutCSR": func(t *testing.T, name string) {
+					assert.Error(t, opts.PutCertRequestFromMemory(d))
+				},
+				"SucceedsAfterCertRequestInMemory": func(t *testing.T, name string) {
+					_, _, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+					crt, err := opts.SignInMemory(d)
+					require.NoError(t, err)
+
+					rawCrt, err := crt.GetRawCertificate()
+					require.NoError(t, err)
+
+					checkMatchingCert(t, opts, rawCrt)
+				},
+				"SucceedsAfterCertRequest": func(t *testing.T, name string) {
+					require.NoError(t, opts.CertRequest(d))
+					crt, err := opts.SignInMemory(d)
+					require.NoError(t, err)
+
+					rawCrt, err := crt.GetRawCertificate()
+					require.NoError(t, err)
+					checkMatchingCert(t, opts, rawCrt)
+				},
+				"ReturnsIdenticalAsSubsequentSign": func(t *testing.T, name string) {
+					_, _, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+
+					crt, err := opts.SignInMemory(d)
+					require.NoError(t, err)
+
+					pemCrt, err := crt.Export()
+					require.NoError(t, err)
+
+					require.NoError(t, opts.Sign(d))
+
+					dbCrt, err := d.Get(depot.CrtTag(name))
+					require.NoError(t, err)
+
+					assert.Equal(t, dbCrt, pemCrt)
+				},
+				"ReturnsIdenticalOnSubsequentCalls": func(t *testing.T, name string) {
+					_, _, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+
+					crt, err := opts.SignInMemory(d)
+					require.NoError(t, err)
+
+					pemCrt, err := crt.Export()
+					require.NoError(t, err)
+
+					sameCrt, err := opts.SignInMemory(d)
+					require.NoError(t, err)
+
+					pemSameCrt, err := sameCrt.Export()
+					require.NoError(t, err)
+
+					assert.Equal(t, pemCrt, pemSameCrt)
+				},
+			} {
+				t.Run(subTestName, func(t *testing.T) {
+					name, err := opts.getFormattedCertificateRequestName()
+					require.NoError(t, err)
+					require.NoError(t, clearByName(d, name))
+					resetOpts(opts)
+					defer func() {
+						assert.NoError(t, clearByName(d, name))
+						resetOpts(opts)
+					}()
+
+					subTestCase(t, name)
+				})
+			}
+		},
+		"PutCertFromMemory": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+			for subTestName, subTestCase := range map[string]func(t *testing.T, name string){
+				"FailsWithoutSignInMemory": func(t *testing.T, name string) {
+					assert.Error(t, opts.PutCertFromMemory(d))
+				},
+				"SucceedsWithSignInMemory": func(t *testing.T, name string) {
+					_, _, err := opts.CertRequestInMemory(d)
+					require.NoError(t, err)
+					cert, err := opts.SignInMemory(d)
+					require.NoError(t, err)
+					require.NoError(t, opts.PutCertFromMemory(d))
+
+					pemCert, err := cert.Export()
+					require.NoError(t, err)
+					depotCert, err := d.Get(depot.CrtTag(name))
+					require.NoError(t, err)
+					assert.Equal(t, pemCert, depotCert)
+				},
+			} {
+				t.Run(subTestName, func(t *testing.T) {
+					name, err := opts.getFormattedCertificateRequestName()
+					require.NoError(t, err)
+					require.NoError(t, clearByName(d, name))
+					resetOpts(opts)
+
+					defer func() {
+						assert.NoError(t, clearByName(d, name))
+						resetOpts(opts)
+					}()
+
+					subTestCase(t, name)
+				})
+			}
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			caOpts := &CertificateOptions{
+				Organization:       "mongodb",
+				Country:            "USA",
+				Locality:           "NYC",
+				OrganizationalUnit: "evergreen",
+				Province:           "Manhattan",
+				Expires:            24 * time.Hour,
+				IP:                 []string{"0.0.0.0", "1.1.1.1"},
+				Host:               "evergreen",
+				CA:                 "ca",
+				CommonName:         "ca",
+				CAPassphrase:       "passphrase",
+			}
+
+			tempDir, err := ioutil.TempDir(".", "cert-test")
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, os.RemoveAll(tempDir))
+			}()
+			d, err := depot.NewFileDepot(tempDir)
+			require.NoError(t, err)
+
+			require.NoError(t, caOpts.Init(d))
+
+			opts := &CertificateOptions{
+				CA:                 "ca",
+				CommonName:         "test",
+				Host:               "test",
+				Domain:             []string{"test"},
+				Expires:            24 * time.Hour,
+				Organization:       "10gen",
+				Country:            "Canada",
+				Locality:           "Toronto",
+				Province:           "Ontario",
+				OrganizationalUnit: "perf",
+				IP:                 []string{"0.0.0.0", "1.1.1.1"},
+			}
+
+			testCase(t, d, opts)
+		})
+
 	}
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-820

* Add in-memory variants of `CertRequest` and `Sign` which don't commit them to the depot.
* Add methods to commit them to the depot.