### PR TITLE
MAKE-873: format names passed to certdepot based on key type

### DIFF
--- a/depot_test.go
+++ b/depot_test.go
@@ -136,7 +136,8 @@ func TestDepot(t *testing.T) {
 				}
 			},
 			check: func(t *testing.T, tag *depot.Tag, data []byte) {
-				name, key := getNameAndKey(tag)
+				name, key, err := getNameAndKey(tag)
+				require.NoError(t, err)
 
 				u := &User{}
 				require.NoError(t, session.DB(databaseName).C(collectionName).FindId(name).One(u))
@@ -282,7 +283,8 @@ func TestDepot(t *testing.T) {
 				}
 			},
 			check: func(t *testing.T, tag *depot.Tag, data []byte) {
-				name, key := getNameAndKey(tag)
+				name, key, err := getNameAndKey(tag)
+				require.NoError(t, err)
 
 				u := &User{}
 				coll := client.Database(databaseName).Collection(collectionName)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-873

certdepot currently silently formats names when inserted into the database using the usual certificate request and sign from `CertificateOptions`. However, it does not perform these conversions when calling functions on the mongo certdepot implementations (e.g. `(*mongoDepot).Put()`).