### PR TITLE
EVG-13931: allow certificates to be generated with user-defined options

### DIFF
--- a/depot_test.go
+++ b/depot_test.go
@@ -73,7 +73,8 @@ func TestDepot(t *testing.T) {
 			setup: func() Depot {
 				tempDir, err = ioutil.TempDir(".", "file_depot")
 				require.NoError(t, err)
-				d, err := NewFileDepot(tempDir)
+				var d Depot
+				d, err = NewFileDepot(tempDir)
 				require.NoError(t, err)
 				return d
 			},
@@ -92,11 +93,12 @@ func TestDepot(t *testing.T) {
 						CA:         "root",
 					},
 				}
-				_, err := BootstrapDepot(ctx, conf)
+				_, err = BootstrapDepot(ctx, conf)
 				require.NoError(t, err)
 				// We have to do this because the bootstrapped file depot
 				// bootstrapped does not include any DepotOptions.
-				d, err := MakeFileDepot(tempDir, DepotOptions{
+				var d Depot
+				d, err = MakeFileDepot(tempDir, DepotOptions{
 					CA:                "root",
 					DefaultExpiration: time.Minute,
 				})
@@ -183,7 +185,8 @@ func TestDepot(t *testing.T) {
 						CA:         "root",
 					},
 				}
-				d, err := BootstrapDepot(ctx, conf)
+				var d Depot
+				d, err = BootstrapDepot(ctx, conf)
 				require.NoError(t, err)
 				return d
 			},
@@ -358,7 +361,8 @@ func TestDepot(t *testing.T) {
 						Expires:    time.Minute,
 					},
 				}
-				d, err := BootstrapDepot(ctx, conf)
+				var d Depot
+				d, err = BootstrapDepot(ctx, conf)
 				require.NoError(t, err)
 				return d
 			},

--- a/depot_test.go
+++ b/depot_test.go
@@ -57,23 +57,49 @@ func TestDepot(t *testing.T) {
 
 	type testCase struct {
 		name string
-		test func(t *testing.T, d depot.Depot)
+		test func(t *testing.T, d Depot)
 	}
 
 	for _, impl := range []struct {
-		name    string
-		setup   func() depot.Depot
-		check   func(*testing.T, *depot.Tag, []byte)
-		cleanup func()
-		tests   []testCase
+		name      string
+		setup     func() Depot
+		bootstrap func(t *testing.T) Depot
+		check     func(*testing.T, *depot.Tag, []byte)
+		cleanup   func()
+		tests     []testCase
 	}{
 		{
 			name: "File",
-			setup: func() depot.Depot {
+			setup: func() Depot {
 				tempDir, err = ioutil.TempDir(".", "file_depot")
 				require.NoError(t, err)
-				var d *depot.FileDepot
-				d, err = depot.NewFileDepot(tempDir)
+				d, err := NewFileDepot(tempDir)
+				require.NoError(t, err)
+				return d
+			},
+			bootstrap: func(t *testing.T) Depot {
+				conf := BootstrapDepotConfig{
+					FileDepot: tempDir,
+					CAName:    "root",
+					CAOpts: &CertificateOptions{
+						CommonName: "root",
+						Expires:    time.Minute,
+					},
+					ServiceName: "localhost",
+					ServiceOpts: &CertificateOptions{
+						CommonName: "localhost",
+						Host:       "localhost",
+						CA:         "root",
+					},
+				}
+				_, err := BootstrapDepot(ctx, conf)
+				require.NoError(t, err)
+				// We have to do this because the bootstrapped file depot
+				// bootstrapped does not include any DepotOptions.
+				d, err := MakeFileDepot(tempDir, DepotOptions{
+					CA:                "root",
+					DefaultExpiration: time.Minute,
+				})
 				require.NoError(t, err)
 				return d
 			},
@@ -97,7 +123,7 @@ func TestDepot(t *testing.T) {
 			tests: []testCase{
 				{
 					name: "PutFailsWithExisting",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
 						assert.NoError(t, d.Put(depot.CrtTag(name), []byte("data")))
@@ -115,7 +141,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "DeleteWhenDNE",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
 						assert.Error(t, d.Delete(depot.CrtTag(name)))
@@ -128,12 +154,38 @@ func TestDepot(t *testing.T) {
 		},
 		{
 			name: "LegacyMongoDB",
-			setup: func() depot.Depot {
+			setup: func() Depot {
 				return &mgoCertDepot{
 					session:        session,
 					databaseName:   databaseName,
 					collectionName: collectionName,
 				}
+			},
+			bootstrap: func(t *testing.T) Depot {
+				conf := BootstrapDepotConfig{
+					MongoDepot: &MongoDBOptions{
+						DatabaseName:   databaseName,
+						CollectionName: collectionName,
+						DepotOptions: DepotOptions{
+							CA:                "root",
+							DefaultExpiration: time.Minute,
+						},
+					},
+					CAName: "root",
+					CAOpts: &CertificateOptions{
+						CommonName: "root",
+						Expires:    time.Minute,
+					},
+					ServiceName: "localhost",
+					ServiceOpts: &CertificateOptions{
+						CommonName: "localhost",
+						Host:       "localhost",
+						CA:         "root",
+					},
+				}
+				d, err := BootstrapDepot(ctx, conf)
+				require.NoError(t, err)
+				return d
 			},
 			check: func(t *testing.T, tag *depot.Tag, data []byte) {
 				var name, key string
@@ -166,7 +218,7 @@ func TestDepot(t *testing.T) {
 			tests: []testCase{
 				{
 					name: "PutUpdates",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 						user := &User{
 							ID:            name,
@@ -221,7 +273,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "CheckReturnsFalseOnExistingUserWithNoData",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "alice"
 						u := &User{
 							ID: name,
@@ -236,7 +288,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "GetFailsOnExistingUserWithNoData",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 						u := &User{
 							ID: name,
@@ -262,7 +314,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "DeleteWhenDNE",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
 						assert.NoError(t, d.Delete(depot.CrtTag(name)))
@@ -275,13 +327,40 @@ func TestDepot(t *testing.T) {
 		},
 		{
 			name: "MongoDB",
-			setup: func() depot.Depot {
+			setup: func() Depot {
 				return &mongoDepot{
 					ctx:            ctx,
 					client:         client,
 					databaseName:   databaseName,
 					collectionName: collectionName,
 				}
+			},
+			bootstrap: func(t *testing.T) Depot {
+				conf := BootstrapDepotConfig{
+					MongoDepot: &MongoDBOptions{
+						DatabaseName:   databaseName,
+						CollectionName: collectionName,
+						DepotOptions: DepotOptions{
+							CA:                "root",
+							DefaultExpiration: time.Minute,
+						},
+					},
+					CAName: "root",
+					CAOpts: &CertificateOptions{
+						CommonName: "root",
+						Expires:    time.Minute,
+					},
+					ServiceName: "localhost",
+					ServiceOpts: &CertificateOptions{
+						CommonName: "localhost",
+						Host:       "localhost",
+						CA:         "root",
+						Expires:    time.Minute,
+					},
+				}
+				d, err := BootstrapDepot(ctx, conf)
+				require.NoError(t, err)
+				return d
 			},
 			check: func(t *testing.T, tag *depot.Tag, data []byte) {
 				var name, key string
@@ -312,7 +391,7 @@ func TestDepot(t *testing.T) {
 			tests: []testCase{
 				{
 					name: "PutUpdates",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						coll := client.Database(databaseName).Collection(collectionName)
 						const name = "bob"
 						user := &User{
@@ -369,7 +448,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "CheckReturnsFalseOnExistingUserWithNoData",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "alice"
 						u := &User{
 							ID: name,
@@ -385,7 +464,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "GetFailsOnExistingUserWithNoData",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 						u := &User{
 							ID: name,
@@ -412,7 +491,7 @@ func TestDepot(t *testing.T) {
 				},
 				{
 					name: "DeleteWhenDNE",
-					test: func(t *testing.T, d depot.Depot) {
+					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
 						assert.NoError(t, d.Delete(depot.CrtTag(name)))
@@ -621,6 +700,61 @@ func TestDepot(t *testing.T) {
 					impl.check(t, depot.PrivKeyTag(name), data)
 					impl.check(t, depot.CsrTag(name), data)
 					impl.check(t, depot.CrlTag(name), data)
+				})
+			})
+			t.Run("Generate", func(t *testing.T) {
+				_ = impl.setup()
+				d := impl.bootstrap(t)
+				defer impl.cleanup()
+				const name = "alice"
+
+				t.Run("FailsWithInvalidName", func(t *testing.T) {
+					creds, err := d.Generate("")
+					assert.Error(t, err)
+					assert.Zero(t, creds)
+				})
+				t.Run("GeneratesCertificateInMemory", func(t *testing.T) {
+					creds, err := d.Generate(name)
+					require.NoError(t, err)
+					assert.NotZero(t, creds)
+					assert.Equal(t, name, creds.ServerName)
+
+					data, err := d.Get(depot.CsrTag(name))
+					assert.Error(t, err)
+					assert.Zero(t, data)
+
+					data, err = d.Get(depot.CrtTag(name))
+					assert.Error(t, err)
+					assert.Zero(t, data)
+				})
+			})
+			t.Run("GenerateWithOptions", func(t *testing.T) {
+				_ = impl.setup()
+				d := impl.bootstrap(t)
+				defer impl.cleanup()
+				const name = "alice"
+
+				t.Run("FailsWithZeroOptions", func(t *testing.T) {
+					creds, err := d.GenerateWithOptions(CertificateOptions{})
+					assert.Error(t, err)
+					assert.Zero(t, creds)
+				})
+				t.Run("GeneratesCertificateInMemory", func(t *testing.T) {
+					creds, err := d.GenerateWithOptions(CertificateOptions{
+						CommonName: name,
+						Host:       name,
+					})
+					require.NoError(t, err)
+					assert.NotZero(t, creds)
+					assert.Equal(t, name, creds.ServerName)
+
+					data, err := d.Get(depot.CsrTag(name))
+					assert.Error(t, err)
+					assert.Zero(t, data)
+
+					data, err = d.Get(depot.CrtTag(name))
+					assert.Error(t, err)
+					assert.Zero(t, data)
 				})
 			})
 		})

--- a/file.go
+++ b/file.go
@@ -40,5 +40,9 @@ func MakeFileDepot(dir string, opts DepotOptions) (Depot, error) {
 func (fd *fileDepot) Save(name string, creds *Credentials) error { return depotSave(fd, name, creds) }
 func (fd *fileDepot) Find(name string) (*Credentials, error)     { return depotFind(fd, name, fd.opts) }
 func (fd *fileDepot) Generate(name string) (*Credentials, error) {
-	return depotGenerate(fd, name, fd.opts)
+	return depotGenerateDefault(fd, name, fd.opts)
+}
+
+func (fd *fileDepot) GenerateWithOptions(opts CertificateOptions) (*Credentials, error) {
+	return depotGenerate(fd, opts.CommonName, fd.opts, opts)
 }

--- a/interface.go
+++ b/interface.go
@@ -13,7 +13,6 @@ type Depot interface {
 	Save(string, *Credentials) error
 	Find(string) (*Credentials, error)
 	Generate(string) (*Credentials, error)
-	// kim: TODO: test and validate in staging
 	GenerateWithOptions(CertificateOptions) (*Credentials, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,8 @@ type Depot interface {
 	Save(string, *Credentials) error
 	Find(string) (*Credentials, error)
 	Generate(string) (*Credentials, error)
+	// kim: TODO: test and validate in staging
+	GenerateWithOptions(CertificateOptions) (*Credentials, error)
 }
 
 // DepotOptions capture default options used during certificate

--- a/mgo_depot.go
+++ b/mgo_depot.go
@@ -165,7 +165,11 @@ func (m *mgoCertDepot) Delete(tag *depot.Tag) error {
 func (m *mgoCertDepot) Save(name string, creds *Credentials) error { return depotSave(m, name, creds) }
 func (m *mgoCertDepot) Find(name string) (*Credentials, error)     { return depotFind(m, name, m.opts) }
 func (m *mgoCertDepot) Generate(name string) (*Credentials, error) {
-	return depotGenerate(m, name, m.opts)
+	return depotGenerateDefault(m, name, m.opts)
+}
+
+func (m *mgoCertDepot) GenerateWithOptions(opts CertificateOptions) (*Credentials, error) {
+	return depotGenerate(m, opts.CommonName, m.opts, opts)
 }
 
 func errNotNotFound(err error) bool {

--- a/mongodb_depot.go
+++ b/mongodb_depot.go
@@ -176,7 +176,11 @@ func (m *mongoDepot) Delete(tag *depot.Tag) error {
 func (m *mongoDepot) Save(name string, creds *Credentials) error { return depotSave(m, name, creds) }
 func (m *mongoDepot) Find(name string) (*Credentials, error)     { return depotFind(m, name, m.opts) }
 func (m *mongoDepot) Generate(name string) (*Credentials, error) {
-	return depotGenerate(m, name, m.opts)
+	return depotGenerateDefault(m, name, m.opts)
+}
+
+func (m *mongoDepot) GenerateWithOptions(opts CertificateOptions) (*Credentials, error) {
+	return depotGenerate(m, opts.CommonName, m.opts, opts)
 }
 
 func errNotNoDocuments(err error) bool {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13931

Add a `GenerateWithOptions` method parallel to `Generate`, except it allows more user configuration of the certificate options. The certificate made by `Generate` is not flexible enough for some certificate needs (e.g. setting IP addresses).