### PR TITLE
EVG-14382: Add a CheckWithError method to the Depot interface

### DIFF
--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/square/certstrap/depot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -208,9 +207,9 @@ func TestBootstrapDepot(t *testing.T) {
 		Expires:    time.Hour,
 	}
 	require.NoError(t, opts.Init(tempDepot))
-	caCert, err := tempDepot.Get(depot.CrtTag(caName))
+	caCert, err := tempDepot.Get(CrtTag(caName))
 	require.NoError(t, err)
-	caKey, err := tempDepot.Get(depot.PrivKeyTag(caName))
+	caKey, err := tempDepot.Get(PrivKeyTag(caName))
 	require.NoError(t, err)
 
 	for _, impl := range []struct {
@@ -289,22 +288,22 @@ func TestBootstrapDepot(t *testing.T) {
 						ServiceName: serviceName,
 					},
 					setup: func(d Depot) {
-						assert.NoError(t, d.Put(depot.CrtTag(caName), []byte("fake ca cert")))
-						assert.NoError(t, d.Put(depot.PrivKeyTag(caName), []byte("fake ca key")))
-						assert.NoError(t, d.Put(depot.CrtTag(serviceName), []byte("fake service cert")))
-						assert.NoError(t, d.Put(depot.PrivKeyTag(serviceName), []byte("fake service key")))
+						assert.NoError(t, d.Put(CrtTag(caName), []byte("fake ca cert")))
+						assert.NoError(t, d.Put(PrivKeyTag(caName), []byte("fake ca key")))
+						assert.NoError(t, d.Put(CrtTag(serviceName), []byte("fake service cert")))
+						assert.NoError(t, d.Put(PrivKeyTag(serviceName), []byte("fake service key")))
 					},
 					test: func(d Depot) {
-						data, err := d.Get(depot.CrtTag(caName))
+						data, err := d.Get(CrtTag(caName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, []byte("fake ca cert"))
-						data, err = d.Get(depot.PrivKeyTag(caName))
+						data, err = d.Get(PrivKeyTag(caName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, []byte("fake ca key"))
-						data, err = d.Get(depot.CrtTag(serviceName))
+						data, err = d.Get(CrtTag(serviceName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, []byte("fake service cert"))
-						data, err = d.Get(depot.PrivKeyTag(serviceName))
+						data, err = d.Get(PrivKeyTag(serviceName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, []byte("fake service key"))
 					},
@@ -324,10 +323,10 @@ func TestBootstrapDepot(t *testing.T) {
 						},
 					},
 					test: func(d Depot) {
-						data, err := d.Get(depot.CrtTag(caName))
+						data, err := d.Get(CrtTag(caName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, caCert)
-						data, err = d.Get(depot.PrivKeyTag(caName))
+						data, err = d.Get(PrivKeyTag(caName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, caKey)
 					},
@@ -388,10 +387,10 @@ func TestBootstrapDepot(t *testing.T) {
 					} else {
 						require.NoError(t, err)
 
-						assert.True(t, bd.Check(depot.CrtTag(caName)))
-						assert.True(t, bd.Check(depot.PrivKeyTag(caName)))
-						assert.True(t, bd.Check(depot.CrtTag(serviceName)))
-						assert.True(t, bd.Check(depot.PrivKeyTag(serviceName)))
+						assert.True(t, bd.Check(CrtTag(caName)))
+						assert.True(t, bd.Check(PrivKeyTag(caName)))
+						assert.True(t, bd.Check(CrtTag(serviceName)))
+						assert.True(t, bd.Check(PrivKeyTag(serviceName)))
 					}
 
 					if test.test != nil {

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -195,7 +195,7 @@ func TestBootstrapDepot(t *testing.T) {
 	defer cancel()
 	client, err := mongo.Connect(connctx, options.Client().ApplyURI("mongodb://localhost:27017"))
 	require.NoError(t, err)
-	tempDepot, err := depot.NewFileDepot("temp_depot")
+	tempDepot, err := NewFileDepot("temp_depot")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, os.RemoveAll(depotName))
@@ -215,20 +215,20 @@ func TestBootstrapDepot(t *testing.T) {
 
 	for _, impl := range []struct {
 		name          string
-		setup         func(*BootstrapDepotConfig) depot.Depot
-		bootstrapFunc func(BootstrapDepotConfig) (depot.Depot, error)
+		setup         func(*BootstrapDepotConfig) Depot
+		bootstrapFunc func(BootstrapDepotConfig) (Depot, error)
 		tearDown      func()
 	}{
 		{
 			name: "FileDepot",
-			setup: func(conf *BootstrapDepotConfig) depot.Depot {
+			setup: func(conf *BootstrapDepotConfig) Depot {
 				conf.FileDepot = depotName
 
-				d, err := depot.NewFileDepot(depotName)
+				d, err := NewFileDepot(depotName)
 				require.NoError(t, err)
 				return d
 			},
-			bootstrapFunc: func(conf BootstrapDepotConfig) (depot.Depot, error) {
+			bootstrapFunc: func(conf BootstrapDepotConfig) (Depot, error) {
 				return BootstrapDepot(ctx, conf)
 			},
 			tearDown: func() {
@@ -237,7 +237,7 @@ func TestBootstrapDepot(t *testing.T) {
 		},
 		{
 			name: "MongoDepot",
-			setup: func(conf *BootstrapDepotConfig) depot.Depot {
+			setup: func(conf *BootstrapDepotConfig) Depot {
 				conf.MongoDepot = &MongoDBOptions{
 					DatabaseName:   databaseName,
 					CollectionName: depotName,
@@ -247,7 +247,7 @@ func TestBootstrapDepot(t *testing.T) {
 				require.NoError(t, err)
 				return d
 			},
-			bootstrapFunc: func(conf BootstrapDepotConfig) (depot.Depot, error) {
+			bootstrapFunc: func(conf BootstrapDepotConfig) (Depot, error) {
 				return BootstrapDepot(ctx, conf)
 			},
 			tearDown: func() {
@@ -256,7 +256,7 @@ func TestBootstrapDepot(t *testing.T) {
 		},
 		{
 			name: "MongoDepotExistingClient",
-			setup: func(conf *BootstrapDepotConfig) depot.Depot {
+			setup: func(conf *BootstrapDepotConfig) Depot {
 				conf.MongoDepot = &MongoDBOptions{
 					DatabaseName:   databaseName,
 					CollectionName: depotName,
@@ -266,7 +266,7 @@ func TestBootstrapDepot(t *testing.T) {
 				require.NoError(t, err)
 				return d
 			},
-			bootstrapFunc: func(conf BootstrapDepotConfig) (depot.Depot, error) {
+			bootstrapFunc: func(conf BootstrapDepotConfig) (Depot, error) {
 				return BootstrapDepotWithMongoClient(ctx, client, conf)
 			},
 			tearDown: func() {
@@ -278,8 +278,8 @@ func TestBootstrapDepot(t *testing.T) {
 			for _, test := range []struct {
 				name   string
 				conf   BootstrapDepotConfig
-				setup  func(depot.Depot)
-				test   func(depot.Depot)
+				setup  func(Depot)
+				test   func(Depot)
 				hasErr bool
 			}{
 				{
@@ -288,13 +288,13 @@ func TestBootstrapDepot(t *testing.T) {
 						CAName:      caName,
 						ServiceName: serviceName,
 					},
-					setup: func(d depot.Depot) {
+					setup: func(d Depot) {
 						assert.NoError(t, d.Put(depot.CrtTag(caName), []byte("fake ca cert")))
 						assert.NoError(t, d.Put(depot.PrivKeyTag(caName), []byte("fake ca key")))
 						assert.NoError(t, d.Put(depot.CrtTag(serviceName), []byte("fake service cert")))
 						assert.NoError(t, d.Put(depot.PrivKeyTag(serviceName), []byte("fake service key")))
 					},
-					test: func(d depot.Depot) {
+					test: func(d Depot) {
 						data, err := d.Get(depot.CrtTag(caName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, []byte("fake ca cert"))
@@ -323,7 +323,7 @@ func TestBootstrapDepot(t *testing.T) {
 							Expires:    time.Hour,
 						},
 					},
-					test: func(d depot.Depot) {
+					test: func(d Depot) {
 						data, err := d.Get(depot.CrtTag(caName))
 						assert.NoError(t, err)
 						assert.Equal(t, data, caCert)

--- a/cert.go
+++ b/cert.go
@@ -66,13 +66,21 @@ type CertificateOptions struct {
 }
 
 // Init initializes a new CA.
-func (opts *CertificateOptions) Init(wd depot.Depot) error {
+func (opts *CertificateOptions) Init(wd Depot) error {
 	if opts.CommonName == "" {
 		return errors.New("must provide common name of CA")
 	}
 	formattedName := strings.Replace(opts.CommonName, " ", "_", -1)
 
-	if depot.CheckCertificate(wd, formattedName) || depot.CheckPrivateKey(wd, formattedName) {
+	certExists, err := CheckCertificateWithError(wd, formattedName)
+	if err != nil {
+		return err
+	}
+	privKeyExists, err := CheckPrivateKeyWithError(wd, formattedName)
+	if err != nil {
+		return err
+	}
+	if certExists || privKeyExists {
 		return errors.New("CA with specified name already exists")
 	}
 
@@ -131,8 +139,8 @@ func (opts *CertificateOptions) Init(wd depot.Depot) error {
 	return nil
 }
 
-// Reset clears the cached results of CertificateOptions so that the options can
-// be changed after a certificate has already been requested or signed. For
+// Reset clears the cached results of CertificateOptions so that the options
+// can be changed after a certificate has already been requested or signed. For
 // example, if the options have been modified, a new certificate request can be
 // made with the new options by using Reset.
 func (opts *CertificateOptions) Reset() {
@@ -143,7 +151,7 @@ func (opts *CertificateOptions) Reset() {
 
 // CertRequest creates a new certificate signing request (CSR) and key and puts
 // them in the depot.
-func (opts *CertificateOptions) CertRequest(wd depot.Depot) error {
+func (opts *CertificateOptions) CertRequest(wd Depot) error {
 	if _, _, err := opts.CertRequestInMemory(); err != nil {
 		return errors.Wrap(err, "problem creating cert request and key")
 	}
@@ -207,7 +215,7 @@ func (opts *CertificateOptions) CertRequestInMemory() (*pkix.CertificateSigningR
 
 // PutCertRequestFromMemory stores the certificate request and key generated
 // from the options in the depot.
-func (opts *CertificateOptions) PutCertRequestFromMemory(wd depot.Depot) error {
+func (opts *CertificateOptions) PutCertRequestFromMemory(wd Depot) error {
 	if !opts.certRequestedInMemory() {
 		return errors.New("must make cert request first before putting into depot")
 	}
@@ -217,7 +225,15 @@ func (opts *CertificateOptions) PutCertRequestFromMemory(wd depot.Depot) error {
 		return errors.Wrap(err, "problem getting formatted name")
 	}
 
-	if depot.CheckCertificateSigningRequest(wd, formattedName) || depot.CheckPrivateKey(wd, formattedName) {
+	csrExists, err := CheckCertificateSigningRequestWithError(wd, formattedName)
+	if err != nil {
+		return err
+	}
+	privKeyExists, err := CheckPrivateKeyWithError(wd, formattedName)
+	if err != nil {
+		return err
+	}
+	if csrExists || privKeyExists {
 		return errors.New("certificate request has existed")
 	}
 
@@ -239,7 +255,7 @@ func (opts *CertificateOptions) PutCertRequestFromMemory(wd depot.Depot) error {
 }
 
 // Sign signs a CSR with a given CA for a new certificate.
-func (opts *CertificateOptions) Sign(wd depot.Depot) error {
+func (opts *CertificateOptions) Sign(wd Depot) error {
 	_, err := opts.SignInMemory(wd)
 	if err != nil {
 		return errors.Wrap(err, "problem signing certificate request")
@@ -255,7 +271,7 @@ func (opts *CertificateOptions) signedInMemory() bool {
 // SignInMemory is the same as Sign but returns the resulting certificate
 // without putting it in the depot. Use PutCertFromMemory to put the certificate
 // in the depot.
-func (opts *CertificateOptions) SignInMemory(wd depot.Depot) (*pkix.Certificate, error) {
+func (opts *CertificateOptions) SignInMemory(wd Depot) (*pkix.Certificate, error) {
 	if opts.signedInMemory() {
 		return opts.crt, nil
 	}
@@ -283,14 +299,14 @@ func (opts *CertificateOptions) SignInMemory(wd depot.Depot) (*pkix.Certificate,
 		return nil, errors.Wrap(err, "problem getting CA certificate")
 	}
 
-	// validate that crt is allowed to sign certificates
+	// Validate that crt is allowed to sign certificates.
 	rawCrt, err := crt.GetRawCertificate()
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting raw CA certificate")
 	}
-	// we punt on checking BasicConstraintsValid and checking MaxPathLen. The goal
-	// is to prevent accidentally creating invalid certificates, not protecting
-	// against malicious input.
+	// We punt on checking BasicConstraintsValid and checking MaxPathLen.
+	// The goal is to prevent accidentally creating invalid certificates,
+	// not protecting against malicious input.
 	if !rawCrt.IsCA {
 		return nil, errors.Errorf("%s is not allowed to sign certificates", opts.CA)
 	}
@@ -326,13 +342,17 @@ func (opts *CertificateOptions) SignInMemory(wd depot.Depot) (*pkix.Certificate,
 
 // PutCertFromMemory stores the certificate generated from the options in the
 // depot, along with the expiration TTL on the certificate.
-func (opts *CertificateOptions) PutCertFromMemory(wd depot.Depot) error {
+func (opts *CertificateOptions) PutCertFromMemory(wd Depot) error {
 	if !opts.signedInMemory() {
 		return errors.New("must sign cert first before putting into depot")
 	}
 	formattedReqName := strings.Replace(opts.Host, " ", "_", -1)
 
-	if depot.CheckCertificate(wd, formattedReqName) {
+	exists, err := CheckCertificateWithError(wd, formattedReqName)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return errors.New("certificate has existed")
 	}
 
@@ -423,7 +443,7 @@ func getNameAndKey(tag *depot.Tag) (string, string, error) {
 
 // CreateCertificate is a convenience function for creating a certificate
 // request and signing it.
-func (opts *CertificateOptions) CreateCertificate(wd depot.Depot) error {
+func (opts *CertificateOptions) CreateCertificate(wd Depot) error {
 	if err := opts.CertRequest(wd); err != nil {
 		return errors.Wrap(err, "problem creating the certificate request")
 	}
@@ -438,12 +458,14 @@ func (opts *CertificateOptions) CreateCertificate(wd depot.Depot) error {
 // it expires within the duration `after` and creates a new certificate if
 // either condition is met. True is returned if a certificate is created,
 // false otherwise. If the certificate is a CA, the behavior is undefined.
-func (opts *CertificateOptions) CreateCertificateOnExpiration(wd depot.Depot, after time.Duration) (bool, error) {
+func (opts *CertificateOptions) CreateCertificateOnExpiration(wd Depot, after time.Duration) (bool, error) {
 	dne := true
 	var created bool
 	var err error
 
-	if depot.CheckCertificate(wd, opts.CommonName) {
+	if exists, err := CheckCertificateWithError(wd, opts.CommonName); err != nil {
+		return created, err
+	} else if exists {
 		dne, err = DeleteOnExpiration(wd, opts.CommonName, after)
 		if err != nil {
 			return created, errors.Wrap(err, "problem deleting expiring certificate")
@@ -459,7 +481,7 @@ func (opts *CertificateOptions) CreateCertificateOnExpiration(wd depot.Depot, af
 }
 
 // ValidityBounds returns the date range for which the certificate is valid.
-func ValidityBounds(wd depot.Depot, name string) (time.Time, time.Time, error) {
+func ValidityBounds(wd Depot, name string) (time.Time, time.Time, error) {
 	rawCert, err := getRawCertificate(wd, name)
 	if err != nil {
 		return time.Time{}, time.Time{}, errors.Wrap(err, "problem getting raw certificate")
@@ -471,10 +493,12 @@ func ValidityBounds(wd depot.Depot, name string) (time.Time, time.Time, error) {
 // DeleteOnExpiration deletes the given certificate from the depot if it has an
 // expiration date within the duration `after`. True is returned if the
 // certificate is deleted, false otherwise.
-func DeleteOnExpiration(wd depot.Depot, name string, after time.Duration) (bool, error) {
+func DeleteOnExpiration(wd Depot, name string, after time.Duration) (bool, error) {
 	var deleted bool
 
-	if !depot.CheckCertificate(wd, name) {
+	if exists, err := CheckCertificateWithError(wd, name); err != nil {
+		return deleted, err
+	} else if !exists {
 		return deleted, nil
 	}
 
@@ -507,7 +531,7 @@ func DeleteOnExpiration(wd depot.Depot, name string, after time.Duration) (bool,
 	return deleted, nil
 }
 
-func getRawCertificate(d depot.Depot, name string) (*x509.Certificate, error) {
+func getRawCertificate(d Depot, name string) (*x509.Certificate, error) {
 	cert, err := depot.GetCertificate(d, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem getting certificate from the depot")

--- a/cert.go
+++ b/cert.go
@@ -459,11 +459,14 @@ func (opts *CertificateOptions) CreateCertificate(wd Depot) error {
 // either condition is met. True is returned if a certificate is created,
 // false otherwise. If the certificate is a CA, the behavior is undefined.
 func (opts *CertificateOptions) CreateCertificateOnExpiration(wd Depot, after time.Duration) (bool, error) {
+	var (
+		exists  bool
+		created bool
+		err     error
+	)
 	dne := true
-	var created bool
-	var err error
 
-	if exists, err := CheckCertificateWithError(wd, opts.CommonName); err != nil {
+	if exists, err = CheckCertificateWithError(wd, opts.CommonName); err != nil {
 		return created, err
 	} else if exists {
 		dne, err = DeleteOnExpiration(wd, opts.CommonName, after)

--- a/cert.go
+++ b/cert.go
@@ -234,7 +234,7 @@ func (opts *CertificateOptions) PutCertRequestFromMemory(wd Depot) error {
 		return err
 	}
 	if csrExists || privKeyExists {
-		return errors.New("certificate request has existed")
+		return errors.New("certificate request or private key already exists")
 	}
 
 	if err = depot.PutCertificateSigningRequest(wd, formattedName, opts.csr); err != nil {
@@ -353,7 +353,7 @@ func (opts *CertificateOptions) PutCertFromMemory(wd Depot) error {
 		return err
 	}
 	if exists {
-		return errors.New("certificate has existed")
+		return errors.New("certificate already exists")
 	}
 
 	if err := depot.PutCertificate(wd, formattedReqName, opts.crt); err != nil {

--- a/cert_test.go
+++ b/cert_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/mongodb/grip"
-	"github.com/square/certstrap/depot"
 	"github.com/square/certstrap/pkix"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +61,7 @@ func TestInit(t *testing.T) {
 			keyTest: func() {
 				var key *pkix.Key
 
-				key, err = depot.GetPrivateKey(d, opts.CommonName)
+				key, err = GetPrivateKey(d, opts.CommonName)
 				require.NoError(t, err)
 				privKey, ok := key.Private.(*rsa.PrivateKey)
 				require.True(t, ok)
@@ -92,7 +91,7 @@ func TestInit(t *testing.T) {
 				require.NoError(t, err)
 				existingKey, err = pkix.NewKeyFromPrivateKeyPEM(data)
 				require.NoError(t, err)
-				key, err = depot.GetPrivateKey(d, opts.CommonName)
+				key, err = GetPrivateKey(d, opts.CommonName)
 				require.NoError(t, err)
 				assert.Equal(t, existingKey, key)
 			},
@@ -107,7 +106,7 @@ func TestInit(t *testing.T) {
 			keyTest: func() {
 				var key *pkix.Key
 
-				key, err = depot.GetPrivateKey(d, opts.CommonName)
+				key, err = GetPrivateKey(d, opts.CommonName)
 				require.NoError(t, err)
 				privKey, ok := key.Private.(*rsa.PrivateKey)
 				require.True(t, ok)
@@ -122,9 +121,9 @@ func TestInit(t *testing.T) {
 				opts.Passphrase = "passphrase"
 			},
 			keyTest: func() {
-				_, err = depot.GetPrivateKey(d, opts.CommonName)
+				_, err = GetPrivateKey(d, opts.CommonName)
 				assert.Error(t, err)
-				_, err = depot.GetEncryptedPrivateKey(d, opts.CommonName, []byte(opts.Passphrase))
+				_, err = GetEncryptedPrivateKey(d, opts.CommonName, []byte(opts.Passphrase))
 				assert.NoError(t, err)
 
 			},
@@ -217,7 +216,7 @@ func TestCertRequest(t *testing.T) {
 			keyTest: func() {
 				var key *pkix.Key
 
-				key, err = depot.GetPrivateKey(d, opts.Domain[0])
+				key, err = GetPrivateKey(d, opts.Domain[0])
 				require.NoError(t, err)
 				privKey, ok := key.Private.(*rsa.PrivateKey)
 				require.True(t, ok)
@@ -233,7 +232,7 @@ func TestCertRequest(t *testing.T) {
 			keyTest: func() {
 				var key *pkix.Key
 
-				key, err = depot.GetPrivateKey(d, opts.CommonName)
+				key, err = GetPrivateKey(d, opts.CommonName)
 				require.NoError(t, err)
 				privKey, ok := key.Private.(*rsa.PrivateKey)
 				require.True(t, ok)
@@ -264,7 +263,7 @@ func TestCertRequest(t *testing.T) {
 				require.NoError(t, err)
 				existingKey, err = pkix.NewKeyFromPrivateKeyPEM(data)
 				require.NoError(t, err)
-				key, err = depot.GetPrivateKey(d, opts.CommonName)
+				key, err = GetPrivateKey(d, opts.CommonName)
 				require.NoError(t, err)
 				assert.Equal(t, existingKey, key)
 			},
@@ -280,7 +279,7 @@ func TestCertRequest(t *testing.T) {
 			keyTest: func() {
 				var key *pkix.Key
 
-				key, err = depot.GetPrivateKey(d, opts.CommonName)
+				key, err = GetPrivateKey(d, opts.CommonName)
 				require.NoError(t, err)
 				privKey, ok := key.Private.(*rsa.PrivateKey)
 				require.True(t, ok)
@@ -296,9 +295,9 @@ func TestCertRequest(t *testing.T) {
 				opts.Passphrase = "passphrase"
 			},
 			keyTest: func() {
-				_, err = depot.GetPrivateKey(d, opts.CommonName)
+				_, err = GetPrivateKey(d, opts.CommonName)
 				assert.Error(t, err)
-				_, err = depot.GetEncryptedPrivateKey(d, opts.CommonName, []byte(opts.Passphrase))
+				_, err = GetEncryptedPrivateKey(d, opts.CommonName, []byte(opts.Passphrase))
 				assert.NoError(t, err)
 			},
 		},
@@ -339,7 +338,7 @@ func TestCertRequest(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 
-				csr, err := depot.GetCertificateSigningRequest(d, test.csrName)
+				csr, err := GetCertificateSigningRequest(d, test.csrName)
 				require.NoError(t, err)
 				rawCSR, err := csr.GetRawCertificateSigningRequest()
 				require.NoError(t, err)
@@ -363,13 +362,13 @@ func TestInMemory(t *testing.T) {
 	// Resets depot state.
 	clearByName := func(d Depot, name string) error {
 		catcher := grip.NewBasicCatcher()
-		if csrTag := depot.CsrTag(name); d.Check(csrTag) {
+		if csrTag := CsrTag(name); d.Check(csrTag) {
 			catcher.Add(d.Delete(csrTag))
 		}
-		if keyTag := depot.PrivKeyTag(name); d.Check(keyTag) {
+		if keyTag := PrivKeyTag(name); d.Check(keyTag) {
 			catcher.Add(d.Delete(keyTag))
 		}
-		if crtTag := depot.CrtTag(name); d.Check(crtTag) {
+		if crtTag := CrtTag(name); d.Check(crtTag) {
 			catcher.Add(d.Delete(crtTag))
 		}
 		return catcher.Resolve()
@@ -406,8 +405,8 @@ func TestInMemory(t *testing.T) {
 
 					checkMatchingCSR(t, opts, rawCSR)
 
-					assert.False(t, depot.CheckCertificateSigningRequest(d, name))
-					assert.False(t, depot.CheckPrivateKey(d, name))
+					assert.False(t, CheckCertificateSigningRequest(d, name))
+					assert.False(t, CheckPrivateKey(d, name))
 				},
 				"SucceedsAfterCertRequestInDepot": func(t *testing.T, name string) {
 					require.NoError(t, opts.CertRequest(d))
@@ -416,10 +415,10 @@ func TestInMemory(t *testing.T) {
 
 					pemCSR, pemKey := exportCSRAndKey(t, csr, key)
 
-					dbCSR, err := d.Get(depot.CsrTag(name))
+					dbCSR, err := d.Get(CsrTag(name))
 					require.NoError(t, err)
 
-					dbKey, err := d.Get(depot.PrivKeyTag(name))
+					dbKey, err := d.Get(PrivKeyTag(name))
 					require.NoError(t, err)
 
 					assert.Equal(t, dbCSR, pemCSR)
@@ -431,9 +430,9 @@ func TestInMemory(t *testing.T) {
 					pemCSR, pemKey := exportCSRAndKey(t, csr, key)
 
 					require.NoError(t, opts.CertRequest(d))
-					dbCSR, err := d.Get(depot.CsrTag(name))
+					dbCSR, err := d.Get(CsrTag(name))
 					require.NoError(t, err)
-					dbKey, err := d.Get(depot.PrivKeyTag(name))
+					dbKey, err := d.Get(PrivKeyTag(name))
 					require.NoError(t, err)
 
 					assert.Equal(t, dbCSR, pemCSR)
@@ -482,13 +481,13 @@ func TestInMemory(t *testing.T) {
 
 					pemCSR, err := csr.Export()
 					require.NoError(t, err)
-					depotCSR, err := d.Get(depot.CsrTag(name))
+					depotCSR, err := d.Get(CsrTag(name))
 					require.NoError(t, err)
 					assert.Equal(t, pemCSR, depotCSR)
 
 					pemKey, err := key.ExportPrivate()
 					require.NoError(t, err)
-					depotKey, err := d.Get(depot.PrivKeyTag(name))
+					depotKey, err := d.Get(PrivKeyTag(name))
 					require.NoError(t, err)
 					assert.Equal(t, pemKey, depotKey)
 				},
@@ -555,7 +554,7 @@ func TestInMemory(t *testing.T) {
 
 					require.NoError(t, opts.Sign(d))
 
-					dbCrt, err := d.Get(depot.CrtTag(name))
+					dbCrt, err := d.Get(CrtTag(name))
 					require.NoError(t, err)
 
 					assert.Equal(t, dbCrt, pemCrt)
@@ -607,7 +606,7 @@ func TestInMemory(t *testing.T) {
 
 					pemCert, err := cert.Export()
 					require.NoError(t, err)
-					depotCert, err := d.Get(depot.CrtTag(name))
+					depotCert, err := d.Get(CrtTag(name))
 					require.NoError(t, err)
 					assert.Equal(t, pemCert, depotCert)
 				},

--- a/cert_test.go
+++ b/cert_test.go
@@ -24,7 +24,7 @@ func TestInit(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tempDir))
 	}()
-	d, err := depot.NewFileDepot(tempDir)
+	d, err := NewFileDepot(tempDir)
 	require.NoError(t, err)
 
 	opts := &CertificateOptions{
@@ -176,7 +176,7 @@ func TestCertRequest(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tempDir))
 	}()
-	d, err := depot.NewFileDepot(tempDir)
+	d, err := NewFileDepot(tempDir)
 	require.NoError(t, err)
 
 	opts := &CertificateOptions{
@@ -360,8 +360,8 @@ func TestCertRequest(t *testing.T) {
 }
 
 func TestInMemory(t *testing.T) {
-	// Resets depot state
-	clearByName := func(d depot.Depot, name string) error {
+	// Resets depot state.
+	clearByName := func(d Depot, name string) error {
 		catcher := grip.NewBasicCatcher()
 		if csrTag := depot.CsrTag(name); d.Check(csrTag) {
 			catcher.Add(d.Delete(csrTag))
@@ -375,8 +375,8 @@ func TestInMemory(t *testing.T) {
 		return catcher.Resolve()
 	}
 
-	for testName, testCase := range map[string]func(t *testing.T, d depot.Depot, opts *CertificateOptions){
-		"CertRequestInMemory": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+	for testName, testCase := range map[string]func(t *testing.T, d Depot, opts *CertificateOptions){
+		"CertRequestInMemory": func(t *testing.T, d Depot, opts *CertificateOptions) {
 			checkMatchingCSR := func(t *testing.T, opts *CertificateOptions, rawCSR *x509.CertificateRequest) {
 				assert.Equal(t, opts.CommonName, rawCSR.Subject.CommonName)
 				assert.Equal(t, []string{opts.Organization}, rawCSR.Subject.Organization)
@@ -466,7 +466,7 @@ func TestInMemory(t *testing.T) {
 				})
 			}
 		},
-		"PutCertRequest": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+		"PutCertRequest": func(t *testing.T, d Depot, opts *CertificateOptions) {
 			for subTestName, subTestCase := range map[string]func(t *testing.T, name string){
 				"FailsWithoutCertRequestInMemory": func(t *testing.T, name string) {
 					assert.Error(t, opts.PutCertRequestFromMemory(d))
@@ -507,7 +507,7 @@ func TestInMemory(t *testing.T) {
 				})
 			}
 		},
-		"SignInMemory": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+		"SignInMemory": func(t *testing.T, d Depot, opts *CertificateOptions) {
 			checkMatchingCert := func(t *testing.T, opts *CertificateOptions, rawCrt *x509.Certificate) {
 				assert.Equal(t, opts.CommonName, rawCrt.Subject.CommonName)
 				assert.Equal(t, []string{opts.Organization}, rawCrt.Subject.Organization)
@@ -593,7 +593,7 @@ func TestInMemory(t *testing.T) {
 				})
 			}
 		},
-		"PutCertFromMemory": func(t *testing.T, d depot.Depot, opts *CertificateOptions) {
+		"PutCertFromMemory": func(t *testing.T, d Depot, opts *CertificateOptions) {
 			for subTestName, subTestCase := range map[string]func(t *testing.T, name string){
 				"FailsWithoutSignInMemory": func(t *testing.T, name string) {
 					assert.Error(t, opts.PutCertFromMemory(d))
@@ -648,7 +648,7 @@ func TestInMemory(t *testing.T) {
 			defer func() {
 				assert.NoError(t, os.RemoveAll(tempDir))
 			}()
-			d, err := depot.NewFileDepot(tempDir)
+			d, err := NewFileDepot(tempDir)
 			require.NoError(t, err)
 
 			require.NoError(t, caOpts.Init(d))
@@ -679,7 +679,7 @@ func TestSign(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tempDir))
 	}()
-	d, err := depot.NewFileDepot(tempDir)
+	d, err := NewFileDepot(tempDir)
 	require.NoError(t, err)
 
 	caOpts := &CertificateOptions{

--- a/depot_test.go
+++ b/depot_test.go
@@ -18,16 +18,16 @@ import (
 )
 
 func getTagPath(tag *depot.Tag) string {
-	if name := depot.GetNameFromCrtTag(tag); name != "" {
+	if name := GetNameFromCrtTag(tag); name != "" {
 		return name + ".crt"
 	}
-	if name := depot.GetNameFromPrivKeyTag(tag); name != "" {
+	if name := GetNameFromPrivKeyTag(tag); name != "" {
 		return name + ".key"
 	}
-	if name := depot.GetNameFromCsrTag(tag); name != "" {
+	if name := GetNameFromCsrTag(tag); name != "" {
 		return name + ".csr"
 	}
-	if name := depot.GetNameFromCrlTag(tag); name != "" {
+	if name := GetNameFromCrlTag(tag); name != "" {
 		return name + ".crl"
 	}
 	return ""
@@ -128,17 +128,17 @@ func TestDepot(t *testing.T) {
 					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
-						assert.NoError(t, d.Put(depot.CrtTag(name), []byte("data")))
-						assert.Error(t, d.Put(depot.CrtTag(name), []byte("other data")))
+						assert.NoError(t, d.Put(CrtTag(name), []byte("data")))
+						assert.Error(t, d.Put(CrtTag(name), []byte("other data")))
 
-						assert.NoError(t, d.Put(depot.PrivKeyTag(name), []byte("data")))
-						assert.Error(t, d.Put(depot.PrivKeyTag(name), []byte("other data")))
+						assert.NoError(t, d.Put(PrivKeyTag(name), []byte("data")))
+						assert.Error(t, d.Put(PrivKeyTag(name), []byte("other data")))
 
-						assert.NoError(t, d.Put(depot.CsrTag(name), []byte("data")))
-						assert.Error(t, d.Put(depot.CsrTag(name), []byte("other data")))
+						assert.NoError(t, d.Put(CsrTag(name), []byte("data")))
+						assert.Error(t, d.Put(CsrTag(name), []byte("other data")))
 
-						assert.NoError(t, d.Put(depot.CrlTag(name), []byte("data")))
-						assert.Error(t, d.Put(depot.CrlTag(name), []byte("other data")))
+						assert.NoError(t, d.Put(CrlTag(name), []byte("data")))
+						assert.Error(t, d.Put(CrlTag(name), []byte("other data")))
 					},
 				},
 				{
@@ -146,10 +146,10 @@ func TestDepot(t *testing.T) {
 					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
-						assert.Error(t, d.Delete(depot.CrtTag(name)))
-						assert.Error(t, d.Delete(depot.PrivKeyTag(name)))
-						assert.Error(t, d.Delete(depot.CsrTag(name)))
-						assert.Error(t, d.Delete(depot.CrlTag(name)))
+						assert.Error(t, d.Delete(CrtTag(name)))
+						assert.Error(t, d.Delete(PrivKeyTag(name)))
+						assert.Error(t, d.Delete(CsrTag(name)))
+						assert.Error(t, d.Delete(CrlTag(name)))
 					},
 				},
 			},
@@ -234,7 +234,7 @@ func TestDepot(t *testing.T) {
 						time.Sleep(time.Second)
 
 						certData := []byte("bob's new fake certificate")
-						assert.NoError(t, d.Put(depot.CrtTag(name), certData))
+						assert.NoError(t, d.Put(CrtTag(name), certData))
 						u := &User{}
 						require.NoError(t, session.DB(databaseName).C(collectionName).FindId(name).One(u))
 						assert.Equal(t, name, u.ID)
@@ -244,7 +244,7 @@ func TestDepot(t *testing.T) {
 						assert.Equal(t, user.CertRevocList, u.CertRevocList)
 
 						keyData := []byte("bob's new fake private key")
-						assert.NoError(t, d.Put(depot.PrivKeyTag(name), keyData))
+						assert.NoError(t, d.Put(PrivKeyTag(name), keyData))
 						u = &User{}
 						require.NoError(t, session.DB(databaseName).C(collectionName).FindId(name).One(u))
 						assert.Equal(t, name, u.ID)
@@ -254,7 +254,7 @@ func TestDepot(t *testing.T) {
 						assert.Equal(t, user.CertRevocList, u.CertRevocList)
 
 						certReqData := []byte("bob's new fake certificate request")
-						assert.NoError(t, d.Put(depot.CsrTag(name), certReqData))
+						assert.NoError(t, d.Put(CsrTag(name), certReqData))
 						u = &User{}
 						require.NoError(t, session.DB(databaseName).C(collectionName).FindId(name).One(u))
 						assert.Equal(t, name, u.ID)
@@ -264,7 +264,7 @@ func TestDepot(t *testing.T) {
 						assert.Equal(t, user.CertRevocList, u.CertRevocList)
 
 						certRevocListData := []byte("bob's new fake certificate revocation list")
-						assert.NoError(t, d.Put(depot.CrlTag(name), certRevocListData))
+						assert.NoError(t, d.Put(CrlTag(name), certRevocListData))
 						u = &User{}
 						require.NoError(t, session.DB(databaseName).C(collectionName).FindId(name).One(u))
 						assert.Equal(t, name, u.ID)
@@ -283,10 +283,10 @@ func TestDepot(t *testing.T) {
 						}
 						require.NoError(t, session.DB(databaseName).C(collectionName).Insert(u))
 
-						assert.False(t, d.Check(depot.CrtTag(name)))
-						assert.False(t, d.Check(depot.PrivKeyTag(name)))
-						assert.False(t, d.Check(depot.CsrTag(name)))
-						assert.False(t, d.Check(depot.CrlTag(name)))
+						assert.False(t, d.Check(CrtTag(name)))
+						assert.False(t, d.Check(PrivKeyTag(name)))
+						assert.False(t, d.Check(CsrTag(name)))
+						assert.False(t, d.Check(CrlTag(name)))
 					},
 				},
 				{
@@ -298,19 +298,19 @@ func TestDepot(t *testing.T) {
 						}
 						require.NoError(t, session.DB(databaseName).C(collectionName).Insert(u))
 
-						data, err = d.Get(depot.CrtTag(name))
+						data, err = d.Get(CrtTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 
-						data, err = d.Get(depot.PrivKeyTag(name))
+						data, err = d.Get(PrivKeyTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 
-						data, err = d.Get(depot.CsrTag(name))
+						data, err = d.Get(CsrTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 
-						data, err = d.Get(depot.CrlTag(name))
+						data, err = d.Get(CrlTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 					},
@@ -320,10 +320,10 @@ func TestDepot(t *testing.T) {
 					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
-						assert.NoError(t, d.Delete(depot.CrtTag(name)))
-						assert.NoError(t, d.Delete(depot.PrivKeyTag(name)))
-						assert.NoError(t, d.Delete(depot.CsrTag(name)))
-						assert.NoError(t, d.Delete(depot.CrlTag(name)))
+						assert.NoError(t, d.Delete(CrtTag(name)))
+						assert.NoError(t, d.Delete(PrivKeyTag(name)))
+						assert.NoError(t, d.Delete(CsrTag(name)))
+						assert.NoError(t, d.Delete(CrlTag(name)))
 					},
 				},
 			},
@@ -410,7 +410,7 @@ func TestDepot(t *testing.T) {
 						time.Sleep(time.Second)
 
 						certData := []byte("bob's new fake certificate")
-						assert.NoError(t, d.Put(depot.CrtTag(name), certData))
+						assert.NoError(t, d.Put(CrtTag(name), certData))
 						u := &User{}
 						require.NoError(t, coll.FindOne(ctx, bson.M{userIDKey: name}).Decode(u))
 						assert.Equal(t, name, u.ID)
@@ -420,7 +420,7 @@ func TestDepot(t *testing.T) {
 						assert.Equal(t, user.CertRevocList, u.CertRevocList)
 
 						keyData := []byte("bob's new fake private key")
-						assert.NoError(t, d.Put(depot.PrivKeyTag(name), keyData))
+						assert.NoError(t, d.Put(PrivKeyTag(name), keyData))
 						u = &User{}
 						require.NoError(t, coll.FindOne(ctx, bson.M{userIDKey: name}).Decode(u))
 						assert.Equal(t, name, u.ID)
@@ -430,7 +430,7 @@ func TestDepot(t *testing.T) {
 						assert.Equal(t, user.CertRevocList, u.CertRevocList)
 
 						certReqData := []byte("bob's new fake certificate request")
-						assert.NoError(t, d.Put(depot.CsrTag(name), certReqData))
+						assert.NoError(t, d.Put(CsrTag(name), certReqData))
 						u = &User{}
 						require.NoError(t, coll.FindOne(ctx, bson.M{userIDKey: name}).Decode(u))
 						assert.Equal(t, name, u.ID)
@@ -440,7 +440,7 @@ func TestDepot(t *testing.T) {
 						assert.Equal(t, user.CertRevocList, u.CertRevocList)
 
 						certRevocListData := []byte("bob's new fake certificate revocation list")
-						assert.NoError(t, d.Put(depot.CrlTag(name), certRevocListData))
+						assert.NoError(t, d.Put(CrlTag(name), certRevocListData))
 						u = &User{}
 						require.NoError(t, coll.FindOne(ctx, bson.M{userIDKey: name}).Decode(u))
 						assert.Equal(t, name, u.ID)
@@ -460,10 +460,10 @@ func TestDepot(t *testing.T) {
 						_, err = client.Database(databaseName).Collection(collectionName).InsertOne(ctx, u)
 						require.NoError(t, err)
 
-						assert.False(t, d.Check(depot.CrtTag(name)))
-						assert.False(t, d.Check(depot.PrivKeyTag(name)))
-						assert.False(t, d.Check(depot.CsrTag(name)))
-						assert.False(t, d.Check(depot.CrlTag(name)))
+						assert.False(t, d.Check(CrtTag(name)))
+						assert.False(t, d.Check(PrivKeyTag(name)))
+						assert.False(t, d.Check(CsrTag(name)))
+						assert.False(t, d.Check(CrlTag(name)))
 					},
 				},
 				{
@@ -476,19 +476,19 @@ func TestDepot(t *testing.T) {
 						_, err = client.Database(databaseName).Collection(collectionName).InsertOne(ctx, u)
 						require.NoError(t, err)
 
-						data, err = d.Get(depot.CrtTag(name))
+						data, err = d.Get(CrtTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 
-						data, err = d.Get(depot.PrivKeyTag(name))
+						data, err = d.Get(PrivKeyTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 
-						data, err = d.Get(depot.CsrTag(name))
+						data, err = d.Get(CsrTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 
-						data, err = d.Get(depot.CrlTag(name))
+						data, err = d.Get(CrlTag(name))
 						assert.Error(t, err)
 						assert.Nil(t, data)
 					},
@@ -498,10 +498,10 @@ func TestDepot(t *testing.T) {
 					test: func(t *testing.T, d Depot) {
 						const name = "bob"
 
-						assert.NoError(t, d.Delete(depot.CrtTag(name)))
-						assert.NoError(t, d.Delete(depot.PrivKeyTag(name)))
-						assert.NoError(t, d.Delete(depot.CsrTag(name)))
-						assert.NoError(t, d.Delete(depot.CrlTag(name)))
+						assert.NoError(t, d.Delete(CrtTag(name)))
+						assert.NoError(t, d.Delete(PrivKeyTag(name)))
+						assert.NoError(t, d.Delete(CsrTag(name)))
+						assert.NoError(t, d.Delete(CrlTag(name)))
 					},
 				},
 			},
@@ -522,36 +522,36 @@ func TestDepot(t *testing.T) {
 				const name = "bob"
 
 				t.Run("FailsWithNilData", func(t *testing.T) {
-					assert.Error(t, d.Put(depot.CrtTag(name), nil))
+					assert.Error(t, d.Put(CrtTag(name), nil))
 				})
 				t.Run("AddsDataCorrectly", func(t *testing.T) {
 					certData := []byte("bob's fake certificate")
-					assert.NoError(t, d.Put(depot.CrtTag(name), certData))
-					impl.check(t, depot.CrtTag(name), certData)
-					impl.check(t, depot.PrivKeyTag(name), nil)
-					impl.check(t, depot.CsrTag(name), nil)
-					impl.check(t, depot.CrlTag(name), nil)
+					assert.NoError(t, d.Put(CrtTag(name), certData))
+					impl.check(t, CrtTag(name), certData)
+					impl.check(t, PrivKeyTag(name), nil)
+					impl.check(t, CsrTag(name), nil)
+					impl.check(t, CrlTag(name), nil)
 
 					keyData := []byte("bob's fake private key")
-					assert.NoError(t, d.Put(depot.PrivKeyTag(name), keyData))
-					impl.check(t, depot.CrtTag(name), certData)
-					impl.check(t, depot.PrivKeyTag(name), keyData)
-					impl.check(t, depot.CsrTag(name), nil)
-					impl.check(t, depot.CrlTag(name), nil)
+					assert.NoError(t, d.Put(PrivKeyTag(name), keyData))
+					impl.check(t, CrtTag(name), certData)
+					impl.check(t, PrivKeyTag(name), keyData)
+					impl.check(t, CsrTag(name), nil)
+					impl.check(t, CrlTag(name), nil)
 
 					certReqData := []byte("bob's fake certificate request")
-					assert.NoError(t, d.Put(depot.CsrTag(name), certReqData))
-					impl.check(t, depot.CrtTag(name), certData)
-					impl.check(t, depot.PrivKeyTag(name), keyData)
-					impl.check(t, depot.CsrTag(name), certReqData)
-					impl.check(t, depot.CrlTag(name), nil)
+					assert.NoError(t, d.Put(CsrTag(name), certReqData))
+					impl.check(t, CrtTag(name), certData)
+					impl.check(t, PrivKeyTag(name), keyData)
+					impl.check(t, CsrTag(name), certReqData)
+					impl.check(t, CrlTag(name), nil)
 
 					certRevocListData := []byte("bob's fake certificate revocation list")
-					assert.NoError(t, d.Put(depot.CrlTag(name), certRevocListData))
-					impl.check(t, depot.CrtTag(name), certData)
-					impl.check(t, depot.PrivKeyTag(name), keyData)
-					impl.check(t, depot.CsrTag(name), certReqData)
-					impl.check(t, depot.CrlTag(name), certRevocListData)
+					assert.NoError(t, d.Put(CrlTag(name), certRevocListData))
+					impl.check(t, CrtTag(name), certData)
+					impl.check(t, PrivKeyTag(name), keyData)
+					impl.check(t, CsrTag(name), certReqData)
+					impl.check(t, CrlTag(name), certRevocListData)
 				})
 			})
 			t.Run("Check", func(t *testing.T) {
@@ -560,39 +560,39 @@ func TestDepot(t *testing.T) {
 				const name = "alice"
 
 				t.Run("ReturnsFalseWhenDNE", func(t *testing.T) {
-					assert.False(t, d.Check(depot.CrtTag(name)))
-					assert.False(t, d.Check(depot.PrivKeyTag(name)))
-					assert.False(t, d.Check(depot.CsrTag(name)))
-					assert.False(t, d.Check(depot.CrlTag(name)))
+					assert.False(t, d.Check(CrtTag(name)))
+					assert.False(t, d.Check(PrivKeyTag(name)))
+					assert.False(t, d.Check(CsrTag(name)))
+					assert.False(t, d.Check(CrlTag(name)))
 				})
 				t.Run("ReturnsTrueForCorrectTag", func(t *testing.T) {
 					data := []byte("alice's fake certificate")
-					assert.NoError(t, d.Put(depot.CrtTag(name), data))
-					assert.True(t, d.Check(depot.CrtTag(name)))
-					assert.False(t, d.Check(depot.PrivKeyTag(name)))
-					assert.False(t, d.Check(depot.CsrTag(name)))
-					assert.False(t, d.Check(depot.CrlTag(name)))
+					assert.NoError(t, d.Put(CrtTag(name), data))
+					assert.True(t, d.Check(CrtTag(name)))
+					assert.False(t, d.Check(PrivKeyTag(name)))
+					assert.False(t, d.Check(CsrTag(name)))
+					assert.False(t, d.Check(CrlTag(name)))
 
 					data = []byte("alice's fake private key")
-					assert.NoError(t, d.Put(depot.PrivKeyTag(name), data))
-					assert.True(t, d.Check(depot.CrtTag(name)))
-					assert.True(t, d.Check(depot.PrivKeyTag(name)))
-					assert.False(t, d.Check(depot.CsrTag(name)))
-					assert.False(t, d.Check(depot.CrlTag(name)))
+					assert.NoError(t, d.Put(PrivKeyTag(name), data))
+					assert.True(t, d.Check(CrtTag(name)))
+					assert.True(t, d.Check(PrivKeyTag(name)))
+					assert.False(t, d.Check(CsrTag(name)))
+					assert.False(t, d.Check(CrlTag(name)))
 
 					data = []byte("alice's fake certificate request")
-					assert.NoError(t, d.Put(depot.CsrTag(name), data))
-					assert.True(t, d.Check(depot.CrtTag(name)))
-					assert.True(t, d.Check(depot.PrivKeyTag(name)))
-					assert.True(t, d.Check(depot.CsrTag(name)))
-					assert.False(t, d.Check(depot.CrlTag(name)))
+					assert.NoError(t, d.Put(CsrTag(name), data))
+					assert.True(t, d.Check(CrtTag(name)))
+					assert.True(t, d.Check(PrivKeyTag(name)))
+					assert.True(t, d.Check(CsrTag(name)))
+					assert.False(t, d.Check(CrlTag(name)))
 
 					data = []byte("alice's fake certificate revocation list")
-					assert.NoError(t, d.Put(depot.CrlTag(name), data))
-					assert.True(t, d.Check(depot.CrtTag(name)))
-					assert.True(t, d.Check(depot.PrivKeyTag(name)))
-					assert.True(t, d.Check(depot.CsrTag(name)))
-					assert.True(t, d.Check(depot.CrlTag(name)))
+					assert.NoError(t, d.Put(CrlTag(name), data))
+					assert.True(t, d.Check(CrtTag(name)))
+					assert.True(t, d.Check(PrivKeyTag(name)))
+					assert.True(t, d.Check(CsrTag(name)))
+					assert.True(t, d.Check(CrlTag(name)))
 				})
 			})
 			t.Run("Get", func(t *testing.T) {
@@ -601,44 +601,44 @@ func TestDepot(t *testing.T) {
 				const name = "bob"
 
 				t.Run("FailsWhenDNE", func(t *testing.T) {
-					data, err := d.Get(depot.CrtTag(name))
+					data, err := d.Get(CrtTag(name))
 					assert.Error(t, err)
 					assert.Nil(t, data)
 
-					data, err = d.Get(depot.PrivKeyTag(name))
+					data, err = d.Get(PrivKeyTag(name))
 					assert.Error(t, err)
 					assert.Nil(t, data)
 
-					data, err = d.Get(depot.CsrTag(name))
+					data, err = d.Get(CsrTag(name))
 					assert.Error(t, err)
 					assert.Nil(t, data)
 
-					data, err = d.Get(depot.CrlTag(name))
+					data, err = d.Get(CrlTag(name))
 					assert.Error(t, err)
 					assert.Nil(t, data)
 				})
 				t.Run("ReturnsCorrectData", func(t *testing.T) {
 					certData := []byte("bob's fake certificate")
-					assert.NoError(t, d.Put(depot.CrtTag(name), certData))
-					data, err := d.Get(depot.CrtTag(name))
+					assert.NoError(t, d.Put(CrtTag(name), certData))
+					data, err := d.Get(CrtTag(name))
 					assert.NoError(t, err)
 					assert.Equal(t, certData, data)
 
 					keyData := []byte("bob's fake private key")
-					assert.NoError(t, d.Put(depot.PrivKeyTag(name), keyData))
-					data, err = d.Get(depot.PrivKeyTag(name))
+					assert.NoError(t, d.Put(PrivKeyTag(name), keyData))
+					data, err = d.Get(PrivKeyTag(name))
 					assert.NoError(t, err)
 					assert.Equal(t, keyData, data)
 
 					certReqData := []byte("bob's fake certificate request")
-					assert.NoError(t, d.Put(depot.CsrTag(name), certReqData))
-					data, err = d.Get(depot.CsrTag(name))
+					assert.NoError(t, d.Put(CsrTag(name), certReqData))
+					data, err = d.Get(CsrTag(name))
 					assert.NoError(t, err)
 					assert.Equal(t, certReqData, data)
 
 					certRevocListData := []byte("bob's fake certificate revocation list")
-					assert.NoError(t, d.Put(depot.CrlTag(name), certRevocListData))
-					data, err = d.Get(depot.CrlTag(name))
+					assert.NoError(t, d.Put(CrlTag(name), certRevocListData))
+					data, err = d.Get(CrlTag(name))
 					assert.NoError(t, err)
 					assert.Equal(t, certRevocListData, data)
 				})
@@ -653,57 +653,57 @@ func TestDepot(t *testing.T) {
 				keyData := []byte("alice's fake private key")
 				certReqData := []byte("alice's fake certificate request")
 				certRevocListData := []byte("alice's fake certificate revocation list")
-				require.NoError(t, d.Put(depot.CrtTag(deleteName), certData))
-				require.NoError(t, d.Put(depot.PrivKeyTag(deleteName), keyData))
-				require.NoError(t, d.Put(depot.CsrTag(deleteName), certReqData))
-				require.NoError(t, d.Put(depot.CrlTag(deleteName), certRevocListData))
+				require.NoError(t, d.Put(CrtTag(deleteName), certData))
+				require.NoError(t, d.Put(PrivKeyTag(deleteName), keyData))
+				require.NoError(t, d.Put(CsrTag(deleteName), certReqData))
+				require.NoError(t, d.Put(CrlTag(deleteName), certRevocListData))
 
 				data := []byte("bob's data")
-				require.NoError(t, d.Put(depot.CrtTag(name), data))
-				require.NoError(t, d.Put(depot.PrivKeyTag(name), data))
-				require.NoError(t, d.Put(depot.CsrTag(name), data))
-				require.NoError(t, d.Put(depot.CrlTag(name), data))
+				require.NoError(t, d.Put(CrtTag(name), data))
+				require.NoError(t, d.Put(PrivKeyTag(name), data))
+				require.NoError(t, d.Put(CsrTag(name), data))
+				require.NoError(t, d.Put(CrlTag(name), data))
 
 				t.Run("RemovesCorrectData", func(t *testing.T) {
-					assert.NoError(t, d.Delete(depot.CrtTag(deleteName)))
-					impl.check(t, depot.CrtTag(deleteName), nil)
-					impl.check(t, depot.PrivKeyTag(deleteName), keyData)
-					impl.check(t, depot.CsrTag(deleteName), certReqData)
-					impl.check(t, depot.CrlTag(deleteName), certRevocListData)
-					impl.check(t, depot.CrtTag(name), data)
-					impl.check(t, depot.PrivKeyTag(name), data)
-					impl.check(t, depot.CsrTag(name), data)
-					impl.check(t, depot.CrlTag(name), data)
+					assert.NoError(t, d.Delete(CrtTag(deleteName)))
+					impl.check(t, CrtTag(deleteName), nil)
+					impl.check(t, PrivKeyTag(deleteName), keyData)
+					impl.check(t, CsrTag(deleteName), certReqData)
+					impl.check(t, CrlTag(deleteName), certRevocListData)
+					impl.check(t, CrtTag(name), data)
+					impl.check(t, PrivKeyTag(name), data)
+					impl.check(t, CsrTag(name), data)
+					impl.check(t, CrlTag(name), data)
 
-					assert.NoError(t, d.Delete(depot.PrivKeyTag(deleteName)))
-					impl.check(t, depot.CrtTag(deleteName), nil)
-					impl.check(t, depot.PrivKeyTag(deleteName), nil)
-					impl.check(t, depot.CsrTag(deleteName), certReqData)
-					impl.check(t, depot.CrlTag(deleteName), certRevocListData)
-					impl.check(t, depot.CrtTag(name), data)
-					impl.check(t, depot.PrivKeyTag(name), data)
-					impl.check(t, depot.CsrTag(name), data)
-					impl.check(t, depot.CrlTag(name), data)
+					assert.NoError(t, d.Delete(PrivKeyTag(deleteName)))
+					impl.check(t, CrtTag(deleteName), nil)
+					impl.check(t, PrivKeyTag(deleteName), nil)
+					impl.check(t, CsrTag(deleteName), certReqData)
+					impl.check(t, CrlTag(deleteName), certRevocListData)
+					impl.check(t, CrtTag(name), data)
+					impl.check(t, PrivKeyTag(name), data)
+					impl.check(t, CsrTag(name), data)
+					impl.check(t, CrlTag(name), data)
 
-					assert.NoError(t, d.Delete(depot.CsrTag(deleteName)))
-					impl.check(t, depot.CrtTag(deleteName), nil)
-					impl.check(t, depot.PrivKeyTag(deleteName), nil)
-					impl.check(t, depot.CsrTag(deleteName), nil)
-					impl.check(t, depot.CrlTag(deleteName), certRevocListData)
-					impl.check(t, depot.CrtTag(name), data)
-					impl.check(t, depot.PrivKeyTag(name), data)
-					impl.check(t, depot.CsrTag(name), data)
-					impl.check(t, depot.CrlTag(name), data)
+					assert.NoError(t, d.Delete(CsrTag(deleteName)))
+					impl.check(t, CrtTag(deleteName), nil)
+					impl.check(t, PrivKeyTag(deleteName), nil)
+					impl.check(t, CsrTag(deleteName), nil)
+					impl.check(t, CrlTag(deleteName), certRevocListData)
+					impl.check(t, CrtTag(name), data)
+					impl.check(t, PrivKeyTag(name), data)
+					impl.check(t, CsrTag(name), data)
+					impl.check(t, CrlTag(name), data)
 
-					assert.NoError(t, d.Delete(depot.CrlTag(deleteName)))
-					impl.check(t, depot.CrtTag(deleteName), nil)
-					impl.check(t, depot.PrivKeyTag(deleteName), nil)
-					impl.check(t, depot.CsrTag(deleteName), nil)
-					impl.check(t, depot.CrlTag(deleteName), nil)
-					impl.check(t, depot.CrtTag(name), data)
-					impl.check(t, depot.PrivKeyTag(name), data)
-					impl.check(t, depot.CsrTag(name), data)
-					impl.check(t, depot.CrlTag(name), data)
+					assert.NoError(t, d.Delete(CrlTag(deleteName)))
+					impl.check(t, CrtTag(deleteName), nil)
+					impl.check(t, PrivKeyTag(deleteName), nil)
+					impl.check(t, CsrTag(deleteName), nil)
+					impl.check(t, CrlTag(deleteName), nil)
+					impl.check(t, CrtTag(name), data)
+					impl.check(t, PrivKeyTag(name), data)
+					impl.check(t, CsrTag(name), data)
+					impl.check(t, CrlTag(name), data)
 				})
 			})
 			t.Run("Generate", func(t *testing.T) {
@@ -723,11 +723,11 @@ func TestDepot(t *testing.T) {
 					assert.NotZero(t, creds)
 					assert.Equal(t, name, creds.ServerName)
 
-					data, err := d.Get(depot.CsrTag(name))
+					data, err := d.Get(CsrTag(name))
 					assert.Error(t, err)
 					assert.Zero(t, data)
 
-					data, err = d.Get(depot.CrtTag(name))
+					data, err = d.Get(CrtTag(name))
 					assert.Error(t, err)
 					assert.Zero(t, data)
 				})
@@ -752,11 +752,11 @@ func TestDepot(t *testing.T) {
 					assert.NotZero(t, creds)
 					assert.Equal(t, name, creds.ServerName)
 
-					data, err := d.Get(depot.CsrTag(name))
+					data, err := d.Get(CsrTag(name))
 					assert.Error(t, err)
 					assert.Zero(t, data)
 
-					data, err = d.Get(depot.CrtTag(name))
+					data, err = d.Get(CrtTag(name))
 					assert.Error(t, err)
 					assert.Zero(t, data)
 				})

--- a/file.go
+++ b/file.go
@@ -37,8 +37,9 @@ func MakeFileDepot(dir string, opts DepotOptions) (Depot, error) {
 	return fd, nil
 }
 
-func (fd *fileDepot) Save(name string, creds *Credentials) error { return depotSave(fd, name, creds) }
-func (fd *fileDepot) Find(name string) (*Credentials, error)     { return depotFind(fd, name, fd.opts) }
+func (fd *fileDepot) CheckWithError(tag *depot.Tag) (bool, error) { return fd.Check(tag), nil }
+func (fd *fileDepot) Save(name string, creds *Credentials) error  { return depotSave(fd, name, creds) }
+func (fd *fileDepot) Find(name string) (*Credentials, error)      { return depotFind(fd, name, fd.opts) }
 func (fd *fileDepot) Generate(name string) (*Credentials, error) {
 	return depotGenerateDefault(fd, name, fd.opts)
 }

--- a/interface.go
+++ b/interface.go
@@ -6,10 +6,11 @@ import (
 	"github.com/square/certstrap/depot"
 )
 
-// Depot is a superset wrapper around certrstap's depot.Depot interface so users only
-// need to vendor certdepot.
+// Depot is a superset wrapper around certrstap's depot.Depot interface so
+// users only need to vendor certdepot.
 type Depot interface {
 	depot.Depot
+	CheckWithError(tag *depot.Tag) (bool, error)
 	Save(string, *Credentials) error
 	Find(string) (*Credentials, error)
 	Generate(string) (*Credentials, error)

--- a/mgo_depot.go
+++ b/mgo_depot.go
@@ -85,15 +85,14 @@ func (m *mgoCertDepot) Check(tag *depot.Tag) bool {
 	defer session.Close()
 
 	u := &User{}
-	if err = session.DB(m.databaseName).C(m.collectionName).FindId(name).One(u); errNotNotFound(err) {
-		grip.Warning(message.Fields{
-			"db":   m.databaseName,
-			"coll": m.collectionName,
-			"id":   name,
-			"err":  err,
-			"op":   "check",
-		})
-	}
+	err = session.DB(m.databaseName).C(m.collectionName).FindId(name).One(u)
+	grip.WarningWhen(errNotNotFound(err), message.WrapError(err, message.Fields{
+		"db":   m.databaseName,
+		"coll": m.collectionName,
+		"id":   name,
+		"err":  err,
+		"op":   "check",
+	}))
 
 	switch key {
 	case userCertKey:
@@ -106,6 +105,36 @@ func (m *mgoCertDepot) Check(tag *depot.Tag) bool {
 		return u.CertRevocList != ""
 	default:
 		return false
+	}
+}
+
+// CheckWithError returns whether the user and data specified by the tag exists
+// as well as an error in the case of an internal error.
+func (m *mgoCertDepot) CheckWithError(tag *depot.Tag) (bool, error) {
+	name, key, err := getNameAndKey(tag)
+	if err != nil {
+		return false, nil
+	}
+	session := m.session.Clone()
+	defer session.Close()
+
+	u := &User{}
+
+	if err = session.DB(m.databaseName).C(m.collectionName).FindId(name).One(u); errNotNotFound(err) {
+		return false, errors.Wrap(err, "checking depot tag")
+	}
+
+	switch key {
+	case userCertKey:
+		return u.Cert != "", nil
+	case userPrivateKeyKey:
+		return u.PrivateKey != "", nil
+	case userCertReqKey:
+		return u.CertReq != "", nil
+	case userCertRevocListKey:
+		return u.CertRevocList != "", nil
+	default:
+		return false, nil
 	}
 }
 

--- a/mgo_depot.go
+++ b/mgo_depot.go
@@ -113,7 +113,7 @@ func (m *mgoCertDepot) Check(tag *depot.Tag) bool {
 func (m *mgoCertDepot) CheckWithError(tag *depot.Tag) (bool, error) {
 	name, key, err := getNameAndKey(tag)
 	if err != nil {
-		return false, nil
+		return false, errors.Wrap(err, "getting name and key")
 	}
 	session := m.session.Clone()
 	defer session.Close()

--- a/mongodb_depot.go
+++ b/mongodb_depot.go
@@ -124,6 +124,35 @@ func (m *mongoDepot) Check(tag *depot.Tag) bool {
 	}
 }
 
+// CheckWithError returns whether the user and data specified by the tag exists
+// as well as an error in the case of an internal error.
+func (m *mongoDepot) CheckWithError(tag *depot.Tag) (bool, error) {
+	name, key, err := getNameAndKey(tag)
+	if err != nil {
+		return false, nil
+	}
+
+	u := &User{}
+
+	err = m.client.Database(m.databaseName).Collection(m.collectionName).FindOne(m.ctx, bson.D{{Key: userIDKey, Value: name}}).Decode(u)
+	if errNotNoDocuments(err) {
+		return false, errors.Wrap(err, "checking depot tag")
+	}
+
+	switch key {
+	case userCertKey:
+		return u.Cert != "", nil
+	case userPrivateKeyKey:
+		return u.PrivateKey != "", nil
+	case userCertReqKey:
+		return u.CertReq != "", nil
+	case userCertRevocListKey:
+		return u.CertRevocList != "", nil
+	default:
+		return false, nil
+	}
+}
+
 // Get reads the data for the user specified by tag. Returns an error if the
 // user does not exist or if the data is empty.
 func (m *mongoDepot) Get(tag *depot.Tag) ([]byte, error) {

--- a/mongodb_depot.go
+++ b/mongodb_depot.go
@@ -129,7 +129,7 @@ func (m *mongoDepot) Check(tag *depot.Tag) bool {
 func (m *mongoDepot) CheckWithError(tag *depot.Tag) (bool, error) {
 	name, key, err := getNameAndKey(tag)
 	if err != nil {
-		return false, nil
+		return false, errors.Wrap(err, "getting name and key")
 	}
 
 	u := &User{}

--- a/pkix.go
+++ b/pkix.go
@@ -28,23 +28,22 @@ func CrlTag(prefix string) *depot.Tag {
 	return depot.CrlTag(prefix)
 }
 
-// GetNameFromCrtTag returns the host name from a certificate tag.
+// GetNameFromCrtTag returns the name from a certificate tag.
 func GetNameFromCrtTag(tag *depot.Tag) string {
 	return depot.GetNameFromCrtTag(tag)
 }
 
-// GetNameFromPrivKeyTag returns the host name from a private key tag.
+// GetNameFromPrivKeyTag returns the name from a private key tag.
 func GetNameFromPrivKeyTag(tag *depot.Tag) string {
 	return depot.GetNameFromPrivKeyTag(tag)
 }
 
-// GetNameFromCsrTag returns the host name from a certificate request tag.
+// GetNameFromCsrTag returns the name from a certificate request tag.
 func GetNameFromCsrTag(tag *depot.Tag) string {
 	return depot.GetNameFromCsrTag(tag)
 }
 
-// GetNameFromCrlTag returns the host name from a certificate revocation list
-// tag.
+// GetNameFromCrlTag returns the name from a certificate revocation list tag.
 func GetNameFromCrlTag(tag *depot.Tag) string {
 	return depot.GetNameFromCrlTag(tag)
 }
@@ -84,27 +83,27 @@ func PutCertificateSigningRequest(d Depot, name string, csr *pkix.CertificateSig
 }
 
 // CheckCertificateSigningRequest checks the depot for existence of a
-// certificate signing request for a given host name.
+// certificate signing request for a given name.
 func CheckCertificateSigningRequest(d Depot, name string) bool {
 	return depot.CheckCertificateSigningRequest(d, name)
 }
 
 // CheckCertificateSigningRequestWithError checks the depot for existence of a
-// certificate signing request for a given host name. In the event of an
-// internal error, an error is returned.
+// certificate signing request for a given name. In the event of an internal
+// error, an error is returned.
 func CheckCertificateSigningRequestWithError(d Depot, name string) (bool, error) {
 	exists, err := d.CheckWithError(CsrTag(name))
 	return exists, errors.Wrap(err, "checking certificate signing request")
 }
 
 // GetCertificateSigningRequest retrieves a certificate signing request for a
-// given host name from the depot.
+// given name from the depot.
 func GetCertificateSigningRequest(d Depot, name string) (crt *pkix.CertificateSigningRequest, err error) {
 	return depot.GetCertificateSigningRequest(d, name)
 }
 
 // DeleteCertificateSigningRequest removes a certificate signing request for a
-// given host name from the depot.
+// given name from the depot.
 func DeleteCertificateSigningRequest(d Depot, name string) error {
 	return depot.DeleteCertificateSigningRequest(d, name)
 }
@@ -132,8 +131,8 @@ func GetPrivateKey(d Depot, name string) (key *pkix.Key, err error) {
 	return depot.GetPrivateKey(d, name)
 }
 
-// DeletePrivateKey removes a private key for a given host name from the depot.
-// This works for both encrypted and unencrypted private keys.
+// DeletePrivateKey removes a private key for a given name from the depot. This
+// works for both encrypted and unencrypted private keys.
 func DeletePrivateKey(d Depot, name string) error {
 	return d.Delete(depot.PrivKeyTag(name))
 }

--- a/pkix.go
+++ b/pkix.go
@@ -18,7 +18,7 @@ func PrivKeyTag(prefix string) *depot.Tag {
 	return depot.PrivKeyTag(prefix)
 }
 
-// CsrTag returns a tag corresponding to a certificate signature request file.
+// CsrTag returns a tag corresponding to a certificate signature request.
 func CsrTag(prefix string) *depot.Tag {
 	return depot.CsrTag(prefix)
 }
@@ -28,126 +28,145 @@ func CrlTag(prefix string) *depot.Tag {
 	return depot.CrlTag(prefix)
 }
 
-// GetNameFromCrtTag returns the host name from a certificate file tag.
+// GetNameFromCrtTag returns the host name from a certificate tag.
 func GetNameFromCrtTag(tag *depot.Tag) string {
 	return depot.GetNameFromCrtTag(tag)
 }
 
-// GetNameFromPrivKeyTag returns the host name from a private key file tag.
+// GetNameFromPrivKeyTag returns the host name from a private key tag.
 func GetNameFromPrivKeyTag(tag *depot.Tag) string {
 	return depot.GetNameFromPrivKeyTag(tag)
 }
 
-// GetNameFromCsrTag returns the host name from a certificate request file tag.
+// GetNameFromCsrTag returns the host name from a certificate request tag.
 func GetNameFromCsrTag(tag *depot.Tag) string {
 	return depot.GetNameFromCsrTag(tag)
 }
 
 // GetNameFromCrlTag returns the host name from a certificate revocation list
-// file tag.
+// tag.
 func GetNameFromCrlTag(tag *depot.Tag) string {
 	return depot.GetNameFromCrlTag(tag)
 }
 
-// PutCertificate creates a certificate file for a given name in the depot.
-func PutCertificate(d depot.Depot, name string, crt *pkix.Certificate) error {
+// PutCertificate creates a certificate for a given name in the depot.
+func PutCertificate(d Depot, name string, crt *pkix.Certificate) error {
 	return depot.PutCertificate(d, name, crt)
 }
 
-// CheckCertificate checks the depot for existence of a certificate file for a
-// given name.
-func CheckCertificate(d depot.Depot, name string) bool {
+// CheckCertificate checks the depot for existence of a certificate for a given
+// name.
+func CheckCertificate(d Depot, name string) bool {
 	return depot.CheckCertificate(d, name)
 }
 
-// GetCertificate retrieves a certificate file for a given name from the depot.
-func GetCertificate(d depot.Depot, name string) (crt *pkix.Certificate, err error) {
+// CheckCertificateWithError checks the depot for existence of a certificate
+// for a given name. In the event of an internal error, an error is returned.
+func CheckCertificateWithError(d Depot, name string) (bool, error) {
+	exists, err := d.CheckWithError(CrtTag(name))
+	return exists, errors.Wrap(err, "checking certificate")
+}
+
+// GetCertificate retrieves a certificate for a given name from the depot.
+func GetCertificate(d Depot, name string) (crt *pkix.Certificate, err error) {
 	return depot.GetCertificate(d, name)
 }
 
-// DeleteCertificate removes a certificate file for a given name from the
-// depot.
-func DeleteCertificate(d depot.Depot, name string) error {
+// DeleteCertificate removes a certificate for a given name from the depot.
+func DeleteCertificate(d Depot, name string) error {
 	return depot.DeleteCertificate(d, name)
 }
 
-// PutCertificateSigningRequest creates a certificate signing request file for
-// a given name and csr in the depot.
-func PutCertificateSigningRequest(d depot.Depot, name string, csr *pkix.CertificateSigningRequest) error {
+// PutCertificateSigningRequest creates a certificate signing request for a
+// given name and csr in the depot.
+func PutCertificateSigningRequest(d Depot, name string, csr *pkix.CertificateSigningRequest) error {
 	return depot.PutCertificateSigningRequest(d, name, csr)
 }
 
 // CheckCertificateSigningRequest checks the depot for existence of a
-// certificate signing request file for a given host name.
-func CheckCertificateSigningRequest(d depot.Depot, name string) bool {
+// certificate signing request for a given host name.
+func CheckCertificateSigningRequest(d Depot, name string) bool {
 	return depot.CheckCertificateSigningRequest(d, name)
 }
 
-// GetCertificateSigningRequest retrieves a certificate signing request file
-// for a given host name from the depot.
-func GetCertificateSigningRequest(d depot.Depot, name string) (crt *pkix.CertificateSigningRequest, err error) {
+// CheckCertificateSigningRequestWithError checks the depot for existence of a
+// certificate signing request for a given host name. In the event of an
+// internal error, an error is returned.
+func CheckCertificateSigningRequestWithError(d Depot, name string) (bool, error) {
+	exists, err := d.CheckWithError(CsrTag(name))
+	return exists, errors.Wrap(err, "checking certificate signing request")
+}
+
+// GetCertificateSigningRequest retrieves a certificate signing request for a
+// given host name from the depot.
+func GetCertificateSigningRequest(d Depot, name string) (crt *pkix.CertificateSigningRequest, err error) {
 	return depot.GetCertificateSigningRequest(d, name)
 }
 
-// DeleteCertificateSigningRequest removes a certificate signing request file
-// for a given host name from the depot.
-func DeleteCertificateSigningRequest(d depot.Depot, name string) error {
+// DeleteCertificateSigningRequest removes a certificate signing request for a
+// given host name from the depot.
+func DeleteCertificateSigningRequest(d Depot, name string) error {
 	return depot.DeleteCertificateSigningRequest(d, name)
 }
 
-// PutPrivateKey creates a private key file for a given name in the depot.
-func PutPrivateKey(d depot.Depot, name string, key *pkix.Key) error {
+// PutPrivateKey creates a private key for a given name in the depot.
+func PutPrivateKey(d Depot, name string, key *pkix.Key) error {
 	return depot.PutPrivateKey(d, name, key)
 }
 
-// CheckPrivateKey checks the depot for existence of a private key file for a
+// CheckPrivateKey checks the depot for existence of a private key for a given
 // given name.
-func CheckPrivateKey(d depot.Depot, name string) bool {
+func CheckPrivateKey(d Depot, name string) bool {
 	return depot.CheckPrivateKey(d, name)
 }
 
-// GetPrivateKey retrieves a private key file for a given name from the depot.
-func GetPrivateKey(d depot.Depot, name string) (key *pkix.Key, err error) {
+// CheckPrivateKeyWithError checks the depot for existence of a private key for
+// a given name. In the event of an internal error, an error is returned.
+func CheckPrivateKeyWithError(d Depot, name string) (bool, error) {
+	exists, err := d.CheckWithError(PrivKeyTag(name))
+	return exists, errors.Wrap(err, "checking private key")
+}
+
+// GetPrivateKey retrieves a private key for a given name from the depot.
+func GetPrivateKey(d Depot, name string) (key *pkix.Key, err error) {
 	return depot.GetPrivateKey(d, name)
 }
 
-// DeletePrivateKey removes a private key file for a given host name from the
-// depot. This works for both encrypted and unencrypted private keys.
+// DeletePrivateKey removes a private key for a given host name from the depot.
+// This works for both encrypted and unencrypted private keys.
 func DeletePrivateKey(d Depot, name string) error {
 	return d.Delete(depot.PrivKeyTag(name))
 }
 
-// PutEncryptedPrivateKey creates an encrypted private key file for a given
-// name in the depot.
-func PutEncryptedPrivateKey(d depot.Depot, name string, key *pkix.Key, passphrase []byte) error {
+// PutEncryptedPrivateKey creates an encrypted private key for a given name in
+// the depot.
+func PutEncryptedPrivateKey(d Depot, name string, key *pkix.Key, passphrase []byte) error {
 	return depot.PutEncryptedPrivateKey(d, name, key, passphrase)
 }
 
-// GetEncryptedPrivateKey retrieves an encrypted private key file for a given
-// name from the depot.
-func GetEncryptedPrivateKey(d depot.Depot, name string, passphrase []byte) (key *pkix.Key, err error) {
+// GetEncryptedPrivateKey retrieves an encrypted private key for a given name
+// from the depot.
+func GetEncryptedPrivateKey(d Depot, name string, passphrase []byte) (key *pkix.Key, err error) {
 	return depot.GetEncryptedPrivateKey(d, name, passphrase)
 }
 
-// PutCertificateRevocationList creates a CRL file for a given name in the
-// depot.
-func PutCertificateRevocationList(d depot.Depot, name string, crl *pkix.CertificateRevocationList) error {
+// PutCertificateRevocationList creates a CRL for a given name in the depot.
+func PutCertificateRevocationList(d Depot, name string, crl *pkix.CertificateRevocationList) error {
 	return depot.PutCertificateRevocationList(d, name, crl)
 }
 
-// GetCertificateRevocationList gets a CRL file for a given name in the depot.
-func GetCertificateRevocationList(d depot.Depot, name string) (*pkix.CertificateRevocationList, error) {
+// GetCertificateRevocationList gets a CRL for a given name in the depot.
+func GetCertificateRevocationList(d Depot, name string) (*pkix.CertificateRevocationList, error) {
 	return depot.GetCertificateRevocationList(d, name)
 }
 
-// DeleteCertificateRevocationList removes a CRL file for a given name in the
-// depot.
+// DeleteCertificateRevocationList removes a CRL for a given name in the depot.
 func DeleteCertificateRevocationList(d Depot, name string) error {
 	return d.Delete(depot.CrlTag(name))
 }
 
 // PutTTL puts a new TTL for a given name in the mongo depot.
-func putTTL(d depot.Depot, name string, expiration time.Time) error {
+func putTTL(d Depot, name string, expiration time.Time) error {
 	md, ok := d.(*mongoDepot)
 	if !ok {
 		return errors.New("cannot put TTL if depot is not a mongo depot")

--- a/superset.go
+++ b/superset.go
@@ -17,7 +17,7 @@ func deleteIfExists(dpt depot.Depot, tags ...*depot.Tag) error {
 	return catcher.Resolve()
 }
 
-func depotSave(dpt depot.Depot, name string, creds *Credentials) error {
+func depotSave(dpt Depot, name string, creds *Credentials) error {
 	if err := deleteIfExists(dpt, CsrTag(name), PrivKeyTag(name), CrtTag(name)); err != nil {
 		return errors.Wrap(err, "problem deleting existing credentials")
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14382

- Add `CheckWithError` to the `Depot` interface, which returns an error if an internal error occurs when checking the depot.
- Replace `depot.Depot` with `certdepot.Depot` in certdepot functions and use `CheckWithError` instead of `Check`.
- Clean up tests.