### PR TITLE
EVG-14486: use archlinux-new distros in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -143,7 +143,8 @@ buildvariants:
       RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - archlinux-test
+      - archlinux-new-small
+      - archlinux-new-large
     tasks:
       - name: ".test"
 
@@ -155,8 +156,8 @@ buildvariants:
       GOROOT: /opt/golang/go1.13
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
-      - archlinux-test
-      - archlinux-build
+      - archlinux-new-small
+      - archlinux-new-large
     tasks:
       - name: ".report"
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14486