### PR TITLE
EVG-15448: add check for mod tidy

### DIFF
--- a/cmd/verify-mod-tidy/verify-mod-tidy.go
+++ b/cmd/verify-mod-tidy/verify-mod-tidy.go
@@ -60,6 +60,7 @@ func main() {
 	}
 }
 
+// readModuleFiles reads the contents of the go module files.
 func readModuleFiles() (goMod []byte, goSum []byte, err error) {
 	goMod, err = os.ReadFile(goModFile)
 	if err != nil {
@@ -72,6 +73,7 @@ func readModuleFiles() (goMod []byte, goSum []byte, err error) {
 	return goMod, goSum, nil
 }
 
+// writeModuleFiles writes the contents of the go module files.
 func writeModuleFiles(goMod, goSum []byte) {
 	if err := os.WriteFile(goModFile, goMod, 0600); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -81,6 +83,7 @@ func writeModuleFiles(goMod, goSum []byte) {
 	}
 }
 
+// runModTidy runs the `go mod tidy` command with the given go binary.
 func runModTidy(ctx context.Context, goBin string) error {
 	cmd := exec.CommandContext(ctx, goBin, "mod", "tidy")
 	cmd.Stdout = os.Stdout

--- a/cmd/verify-mod-tidy/verify-mod-tidy.go
+++ b/cmd/verify-mod-tidy/verify-mod-tidy.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const (
+	goModFile = "go.mod"
+	goSumFile = "go.sum"
+)
+
+// verify-mod-tidy verifies that `go mod tidy` has been run to clean up the
+// go.mod and go.sum files.
+func main() {
+	var (
+		goBin   string
+		timeout time.Duration
+	)
+
+	flag.DurationVar(&timeout, "timeout", 0, "timeout for verifying modules are tidy")
+	flag.StringVar(&goBin, "goBin", "go", "path to go binary to use for mod tidy check")
+	flag.Parse()
+
+	ctx := context.Background()
+	if timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	oldGoMod, err := os.ReadFile(goModFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading file %s: %s\n", goModFile, err)
+		os.Exit(1)
+	}
+	oldGoSum, err := os.ReadFile(goSumFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading file %s: %s\n", goSumFile, err)
+		os.Exit(1)
+	}
+
+	cmd := exec.CommandContext(ctx, goBin, "mod", "tidy")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "mod tidy: %s\n", err)
+		os.Exit(1)
+	}
+
+	newGoMod, err := os.ReadFile(goModFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading file %s: %s\n", goModFile, err)
+		os.Exit(1)
+	}
+	newGoSum, err := os.ReadFile(goSumFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading file %s: %s\n", goSumFile, err)
+		os.Exit(1)
+	}
+
+	if !bytes.Equal(oldGoMod, newGoMod) || !bytes.Equal(oldGoSum, newGoSum) {
+		fmt.Fprintf(os.Stderr, "%s and/or %s are not tidy - please run `go mod tidy`.\n", goModFile, goSumFile)
+		if err := os.WriteFile(goModFile, oldGoMod, 0600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		if err := os.WriteFile(goSumFile, oldGoSum, 0600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(1)
+	}
+}

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -107,6 +107,16 @@ tasks:
     tags: ["report"]
     name: lint-certdepot
 
+  - name: verify-mod-tidy
+    tags: ["report"]
+    commands:
+      - command: git.get_project
+        type: system
+        params:
+          directory: certdepot
+      - func: run-make
+        vars: { target: "${task_name}" }
+
   - <<: *run-build-with-mongodb
     tags: [ "report" ]
     name: coverage-html

--- a/makefile
+++ b/makefile
@@ -149,6 +149,9 @@ check-mongod: mongodb/.get-mongodb
 # start module management targets
 mod-tidy:
 	$(gobin) mod tidy
+# Check if go.mod and go.sum are clean. If they're clean, then mod tidy should not produce a different result.
+verify-mod-tidy:
+	$(gobin) run cmd/verify-mod-tidy/verify-mod-tidy.go -goBin="$(gobin)"
 phony += mod-tidy
 # end module management targets
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15448

Add a helper Go script and CI task to check if `go mod tidy` has been run, which is important for keeping the `go.mod` and `go.sum` clean. If it hasn't been run, the make target and CI task will fail. I ran it locally to check that it works as expected.