### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -118,8 +118,8 @@ tasks:
         vars: { target: "${task_name}" }
 
   - <<: *run-build-with-mongodb
-    tags: [ "report" ]
-    name: coverage-html
+    tags: ["report"]
+    name: html-coverage
 
   - <<: *run-build-with-mongodb
     tags: ["test"]

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -48,7 +48,7 @@ functions:
       working_dir: certdepot
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
   set-up-mongodb:
     - command: subprocess.exec
       type: setup
@@ -132,7 +132,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
@@ -145,7 +144,6 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
@@ -157,7 +155,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
@@ -168,7 +165,6 @@ buildvariants:
   - name: macos
     display_name: macOS 10.14
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.1.tgz
     run_on:
@@ -184,7 +180,6 @@ buildvariants:
       - windows-64-vs2017-small
       - windows-64-vs2017-large
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: C:/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.1.zip
     tasks:

--- a/makefile
+++ b/makefile
@@ -96,9 +96,6 @@ lint-%: $(buildDir)/output.%.lint
 
 # start test and coverage artifacts
 testArgs := -v
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif
@@ -152,7 +149,7 @@ mod-tidy:
 # Check if go.mod and go.sum are clean. If they're clean, then mod tidy should not produce a different result.
 verify-mod-tidy:
 	$(gobin) run cmd/verify-mod-tidy/verify-mod-tidy.go -goBin="$(gobin)"
-phony += mod-tidy
+phony += mod-tidy verify-mod-tidy
 # end module management targets
 
 # start cleanup targets

--- a/makefile
+++ b/makefile
@@ -65,8 +65,8 @@ $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
 lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+htmlCoverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(coverageOutput) $(htmlCoverageOutput) $(lintOutput) $(testOutput)
 # end output files
 
 # start basic development operations
@@ -75,11 +75,11 @@ compile:
 test:$(testOutput)
 lint:$(lintOutput)
 coverage:$(coverageOutput)
-coverage-html:$(coverageHtmlOutput)
+html-coverage:$(htmlCoverageOutput)
 benchmark:
 	$(gobin) test -v -benchmem -bench=. -run="Benchmark.*" -timeout=20m
 
-phony += compile lint test coverage coverage-html benchmark
+phony += compile lint test coverage html-coverage benchmark
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.